### PR TITLE
fix(agent-gateway/terraform): make mcp_internal_dns_zone optional on simple path

### DIFF
--- a/demos/agent-gateway/terraform/variables.tf
+++ b/demos/agent-gateway/terraform/variables.tf
@@ -156,12 +156,17 @@ variable "mcp_internal_dns_zone" {
     name   = optional(string, "mcp-server-internal")
     domain = string
   })
-  # No default — the operator must explicitly choose the DNS suffix because the
-  # right value depends on dns_zone_domain (and on whether Agent Gateway is in
-  # use). See the description above.
+  # null on the simple path (`enable_cloud_run_private_networking = false`); the
+  # cross-variable validation below promotes it to required when the master flag
+  # flips on. Every consumer in main.tf/outputs.tf already guards for null.
+  default = null
   validation {
-    condition     = endswith(var.mcp_internal_dns_zone.domain, ".")
+    condition     = var.mcp_internal_dns_zone == null || endswith(var.mcp_internal_dns_zone.domain, ".")
     error_message = "mcp_internal_dns_zone.domain must end with a trailing dot (e.g. \"mcp.example.com.\")."
+  }
+  validation {
+    condition     = !var.enable_cloud_run_private_networking || var.mcp_internal_dns_zone != null
+    error_message = "mcp_internal_dns_zone is required when enable_cloud_run_private_networking = true (it supplies the per-service domain fronting the MCP internal Application LB). Set it in your tfvars (typically mcp_internal_dns_zone = { domain = \"mcp.<dns_zone_domain>\" }), or leave enable_cloud_run_private_networking = false to use the *.run.app simple path."
   }
 }
 


### PR DESCRIPTION
## Summary

`mcp_internal_dns_zone` had no `default`, so `terraform plan` blocked on an interactive prompt for users on the documented simple path (`enable_cloud_run_private_networking = false`) — even though the variable's description and every consumer treated the value as ignored when the master flag was off.

This change:

- Sets `default = null` on `mcp_internal_dns_zone`.
- Guards the existing trailing-dot validation against `null` (mirroring the pattern already used in `modules/networking/variables.tf:68`).
- Adds a cross-variable `validation` block that requires the zone when `enable_cloud_run_private_networking = true`, with an error message pointing the user at both fixes (set the var, or stay on the simple path). Cross-variable validation is supported on the pinned `required_version >= 1.12.2`.

All consumers in `main.tf`/`outputs.tf` already null-guard the value, so no other files needed changes.

## Test plan

- [x] `terraform fmt -check variables.tf` — passes.
- [x] `terraform validate` — passes.
- [x] Simple-path tfvars (only `project_id` / `organization_id` / `platform_admin_members`): `terraform plan -input=false` no longer prompts; gets past variable validation and only fails reading the (fake) GCP project.
- [x] Secure-path tfvars (`enable_cloud_run_private_networking = true`, no MCP DNS): hard error from the new validation, citing `variables.tf:167` with the helpful message.
- [x] Bad trailing-dot (`domain = "mcp.example.com"`): existing validation still fires, citing `variables.tf:163`.
- [x] Full `example.tfvars`: still plans; only fails on the placeholder project ID.
- [x] `pre-commit run --files demos/agent-gateway/terraform/variables.tf` — fmt, validate, tflint, license, codespell all pass.

## Reporter

Reported by `vaibhavkatkade` (Cloud Shell, `vaibhavkatkade-playground1`) — they hit the prompt running `terraform plan -var-file=terraform.tfvars` on a stripped-down tfvars.