### PR TITLE
chore(agent-gateway): stop tracking terraform backend.conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ override.tf.json
 *_override.tf
 *_override.tf.json
 *.tfplan
+backend.conf
 
 # Go
 bin/

--- a/demos/agent-gateway/terraform/backend.conf
+++ b/demos/agent-gateway/terraform/backend.conf
@@ -1,2 +1,0 @@
-bucket = "duncanjames-agw-tf-state"
-prefix = "agent-gateway"


### PR DESCRIPTION
Local Terraform backend config contains user-specific GCS state bucket and prefix. Add to .gitignore and untrack the upstream copy.