### PR TITLE
feat(agent-gateway): authenticate MCP Cloud Run via SA impersonation

### DIFF
--- a/demos/agent-gateway/src/mortgage-agent/agent/agent.py
+++ b/demos/agent-gateway/src/mortgage-agent/agent/agent.py
@@ -17,6 +17,7 @@
 import logging
 import os
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 from google.adk.agents.llm_agent import Agent
@@ -26,6 +27,109 @@ from google.adk.tools.tool_context import ToolContext
 from . import tools
 
 logger = logging.getLogger(__name__)
+
+
+def _build_impersonation_factory(target_url: str, target_sa_email: str):
+    """Return an httpx_client_factory that signs requests as `target_sa_email`.
+
+    Direct Agent Identity → Cloud Run authentication is not supported (as of
+    2026-05). The supported pattern: agent uses its identity to impersonate a
+    standard IAM SA, then mints an OIDC ID token for that SA and presents it
+    in the Authorization header. Cloud Run validates the token and sees the
+    impersonated SA as the caller. The agent identity must hold
+    roles/iam.serviceAccountTokenCreator on `target_sa_email`, and that SA
+    must hold roles/run.invoker on the Cloud Run service.
+
+    The returned factory matches MCP's McpHttpClientFactory protocol:
+    create_mcp_http_client(headers, timeout, auth) -> httpx.AsyncClient.
+    """
+    # Imported lazily so importing this module never fails when google-auth
+    # isn't installed (e.g. during static analysis or tests that mock out
+    # the registry path).
+    import google.auth
+    import google.auth.transport.requests as gar
+    from google.auth import impersonated_credentials
+
+    # Audience is the origin of the Cloud Run URL (no path/query). Must match
+    # the URL Cloud Run sees in the request.
+    parsed = urlparse(target_url)
+    audience = f"{parsed.scheme}://{parsed.netloc}"
+
+    try:
+        source_creds, source_project = google.auth.default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
+        logger.info(
+            "Impersonation factory ready: target_sa=%s audience=%s source_creds=%s source_project=%s",
+            target_sa_email,
+            audience,
+            type(source_creds).__name__,
+            source_project,
+        )
+        impersonated = impersonated_credentials.Credentials(
+            source_credentials=source_creds,
+            target_principal=target_sa_email,
+            target_scopes=["https://www.googleapis.com/auth/cloud-platform"],
+        )
+        id_token_creds = impersonated_credentials.IDTokenCredentials(
+            target_credentials=impersonated,
+            target_audience=audience,
+            include_email=True,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to build impersonated credentials for target_sa=%s audience=%s — "
+            "MCP calls to %s will fail. Common causes: agent identity missing "
+            "roles/iam.serviceAccountTokenCreator, iamcredentials.googleapis.com disabled, "
+            "or wrong source credentials.",
+            target_sa_email,
+            audience,
+            target_url,
+        )
+        raise
+
+    class _ImpersonatedIDTokenAuth(httpx.Auth):
+        """Per-request httpx auth that refreshes the OIDC token on demand."""
+
+        requires_request_body = False
+
+        def __init__(self, creds, target_url: str):
+            self._creds = creds
+            self._req = gar.Request()
+            self._target_url = target_url
+
+        def auth_flow(self, request):
+            try:
+                if not self._creds.valid:
+                    self._creds.refresh(self._req)
+            except Exception:
+                # ADK wraps this in a TaskGroup and prints only the wrapper's
+                # str(); log the real exception here so it survives.
+                logger.exception(
+                    "OIDC token refresh failed for target_url=%s (impersonation chain "
+                    "agent-identity → %s). Subsequent MCP request will be unauthenticated.",
+                    self._target_url,
+                    target_sa_email,
+                )
+                raise
+            request.headers["Authorization"] = f"Bearer {self._creds.token}"
+            yield request
+
+    auth_handler = _ImpersonatedIDTokenAuth(id_token_creds, target_url)
+
+    def factory(
+        headers: dict[str, str] | None = None,
+        timeout: httpx.Timeout | None = None,
+        auth: httpx.Auth | None = None,
+    ) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            follow_redirects=True,
+            headers=headers,
+            timeout=timeout if timeout is not None else httpx.Timeout(30.0, read=300.0),
+            # Honor an explicit auth from the caller (rare); otherwise inject ours.
+            auth=auth if auth is not None else auth_handler,
+        )
+
+    return factory
+
 
 # Populated by _discover_mcp_toolsets at agent build time. Each entry mirrors
 # what the registry returned plus the resolved tool_name_prefix, so the
@@ -177,6 +281,13 @@ def _discover_mcp_toolsets() -> list:
 
     filter_str = os.environ.get("MCP_REGISTRY_FILTER")
     endpoint = os.environ.get("MCP_REGISTRY_ENDPOINT")
+    invoker_sa_email = os.environ.get("MCP_INVOKER_SA_EMAIL")
+    if not invoker_sa_email:
+        logger.warning(
+            "MCP_INVOKER_SA_EMAIL is not set. MCP calls will use the agent's default "
+            "credentials, which Cloud Run does not accept for IAM-protected services. "
+            "Set MCP_INVOKER_SA_EMAIL to the SA the agent should impersonate."
+        )
 
     try:
         # Imported lazily so the agent module loads even when ADK's optional
@@ -248,6 +359,20 @@ def _discover_mcp_toolsets() -> list:
         if conn_params is not None and hasattr(conn_params, "timeout"):
             conn_params.timeout = 30.0
         resolved_url = getattr(conn_params, "url", None)
+        # Inject SA-impersonation auth so each MCP HTTP call carries an OIDC
+        # ID token for the invoker SA. Cloud Run validates the token and sees
+        # the invoker SA as the caller (the agent identity is not propagated
+        # to Cloud Run; principalSet members are not accepted as run.invoker).
+        if (
+            invoker_sa_email
+            and conn_params is not None
+            and resolved_url
+            and hasattr(conn_params, "httpx_client_factory")
+        ):
+            conn_params.httpx_client_factory = _build_impersonation_factory(
+                target_url=resolved_url,
+                target_sa_email=invoker_sa_email,
+            )
         logger.info(
             "  built toolset: server=%s displayName=%r prefix=%s resolved_url=%s",
             name,

--- a/demos/agent-gateway/src/mortgage-agent/deploy_agent.py
+++ b/demos/agent-gateway/src/mortgage-agent/deploy_agent.py
@@ -340,6 +340,17 @@ def main() -> None:
         default="mortgage-agent",
         help="Discovery Engine authorization/agent name (default: mortgage-agent)",
     )
+    parser.add_argument(
+        "--mcp-invoker-sa",
+        default=os.environ.get("MCP_INVOKER_SA_EMAIL"),
+        help=(
+            "Email of the service account the deployed agent impersonates to mint "
+            "OIDC ID tokens for MCP Cloud Run calls. The agent's identity must hold "
+            "roles/iam.serviceAccountTokenCreator on this SA, and this SA must hold "
+            "roles/run.invoker on each MCP Cloud Run service. Sourced from terraform "
+            "output `agent_mcp_invoker_email`. Default: $MCP_INVOKER_SA_EMAIL."
+        ),
+    )
     args = parser.parse_args()
 
     if not args.project:
@@ -414,14 +425,22 @@ def main() -> None:
         print(f"  Network attachment: {args.network_attachment}")
     if args.enable_agent_identity:
         print("  Agent identity:     enabled")
+    if args.mcp_invoker_sa:
+        print(f"  MCP invoker SA:     {args.mcp_invoker_sa}")
     print()
 
-    # Configure the agent module's runtime environment.
+    # Configure the agent module's runtime environment. These are read at
+    # `from agent.agent import root_agent` time below, so they must be set
+    # before the import — not just in the deployed agent's env_vars.
     os.environ["MODEL_NAME"] = args.model
     os.environ["MCP_REGISTRY_PROJECT"] = args.project
     os.environ["MCP_REGISTRY_LOCATION"] = args.region
     if args.registry_filter:
         os.environ["MCP_REGISTRY_FILTER"] = args.registry_filter
+    if args.registry_endpoint:
+        os.environ["MCP_REGISTRY_ENDPOINT"] = args.registry_endpoint
+    if args.mcp_invoker_sa:
+        os.environ["MCP_INVOKER_SA_EMAIL"] = args.mcp_invoker_sa
 
     import vertexai
 
@@ -458,9 +477,7 @@ def main() -> None:
     if args.enable_agent_identity:
         config["identity_type"] = "AGENT_IDENTITY"
     if args.agent_gateway:
-        config["agent_gateway_config"] = {
-            "agent_to_anywhere_config": {"agent_gateway": args.agent_gateway}
-        }
+        config["agent_gateway_config"] = {"agent_to_anywhere_config": {"agent_gateway": args.agent_gateway}}
 
     agent_src = os.path.join(agent_dir, "agent")
     staging_dir = tempfile.mkdtemp(prefix="agent_deploy_")
@@ -550,6 +567,7 @@ def main() -> None:
                 "MCP_REGISTRY_LOCATION": args.region,
                 **({"MCP_REGISTRY_FILTER": args.registry_filter} if args.registry_filter else {}),
                 **({"MCP_REGISTRY_ENDPOINT": args.registry_endpoint} if args.registry_endpoint else {}),
+                **({"MCP_INVOKER_SA_EMAIL": args.mcp_invoker_sa} if args.mcp_invoker_sa else {}),
             },
             display_name=args.display_name,
             description=description,

--- a/demos/agent-gateway/terraform/main.tf
+++ b/demos/agent-gateway/terraform/main.tf
@@ -351,6 +351,10 @@ module "mcp_services" {
   region             = var.region
   services           = var.mcp_services
   private_networking = var.enable_cloud_run_private_networking
+  # Restricts roles/run.invoker to the agent-mcp-invoker SA. Null when
+  # agent_engine is disabled, in which case mcp-cloud-run skips the binding
+  # and Cloud Run is unreachable until invoker is granted out-of-band.
+  invoker_sa_email = var.enable_agent_engine ? module.agent_engine[0].agent_mcp_invoker_email : null
 
   depends_on = [module.foundation, google_artifact_registry_repository.registry]
 }

--- a/demos/agent-gateway/terraform/modules/agent-engine/main.tf
+++ b/demos/agent-gateway/terraform/modules/agent-engine/main.tf
@@ -87,6 +87,39 @@ resource "google_project_iam_member" "agent_identity_telemetry_writer" {
 }
 
 # =============================================================================
+# Agent MCP invoker service account
+# Agents impersonate this SA at runtime to mint OIDC ID tokens for invoking
+# MCP Cloud Run services. The agent identity holds `roles/iam.serviceAccountTokenCreator`
+# (granted at the project level below). The SA itself is granted
+# `roles/run.invoker` on each MCP service in modules/mcp-cloud-run, so Cloud
+# Run sees the impersonated SA as the caller (the agent identity is not
+# propagated; Cloud Run does not accept agents.global principalSet members
+# directly today, May 2026).
+# =============================================================================
+
+resource "google_service_account" "agent_mcp_invoker" {
+  project      = var.project_id
+  account_id   = "agent-mcp-invoker"
+  display_name = "Agent MCP invoker SA"
+  description  = "OIDC token target for agents calling MCP Cloud Run services. Agent identity has project-level Token Creator allowing impersonation of this and other project SAs."
+}
+
+# Project-level Token Creator binding. We use project-level (not per-SA) so
+# this can be applied with `roles/resourcemanager.projectIamAdmin` alone — no
+# `iam.serviceAccounts.setIamPolicy` required on the terraform principal,
+# which keeps the demo bootstrap minimal. Trade-off: the agent identity can
+# impersonate any SA in the project, not just `agent-mcp-invoker`. This is
+# acceptable for the demo project (which only contains demo SAs); for
+# production, scope this to the specific SA via
+# `google_service_account_iam_member` (requires `roles/iam.serviceAccountIamAdmin`
+# on the apply principal) or with an IAM condition on `resource.name`.
+resource "google_project_iam_member" "agent_identity_token_creator" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountTokenCreator"
+  member  = local.agent_identity_principal
+}
+
+# =============================================================================
 # Demo user IAM bindings
 # Grants roles/aiplatform.user to demo users.
 # =============================================================================

--- a/demos/agent-gateway/terraform/modules/agent-engine/outputs.tf
+++ b/demos/agent-gateway/terraform/modules/agent-engine/outputs.tf
@@ -18,3 +18,8 @@ output "agent_identity_principal" {
   description = "The Agent Identity principalSet for all Agent Engine agents in this project"
   value       = "principalSet://agents.global.org-${var.organization_id}.system.id.goog/attribute.platformContainer/aiplatform/projects/${var.project_number}"
 }
+
+output "agent_mcp_invoker_email" {
+  description = "Email of the SA agents impersonate when invoking MCP Cloud Run services. Pass this to the mcp-cloud-run module's invoker_sa_email and to the agent runtime as MCP_INVOKER_SA_EMAIL."
+  value       = google_service_account.agent_mcp_invoker.email
+}

--- a/demos/agent-gateway/terraform/modules/agent-registry-endpoints/variables.tf
+++ b/demos/agent-gateway/terraform/modules/agent-registry-endpoints/variables.tf
@@ -37,6 +37,7 @@ variable "google_apis" {
     trace                  = "Trace"
     agentregistry          = "Agent Registry"
     iap                    = "Identity-Aware Proxy"
+    iamcredentials         = "IAM Credentials"
   }
 }
 

--- a/demos/agent-gateway/terraform/modules/mcp-cloud-run/main.tf
+++ b/demos/agent-gateway/terraform/modules/mcp-cloud-run/main.tf
@@ -127,18 +127,28 @@ resource "google_cloud_run_v2_service" "mcp" {
   }
 }
 
-# Allow invocation from anywhere ingress lets through. With
-# `INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER` that's the LB only ("allUsers" means
-# "any caller the LB lets in"). With `INGRESS_TRAFFIC_ALL` it means the public
-# internet, which is the intended demo path when private_networking = false.
-# Without this binding the serverless NEG (or any direct client) sends requests
-# with no Authorization header and Cloud Run rejects with 403.
-resource "google_cloud_run_v2_service_iam_member" "internal_lb_invoker" {
-  for_each = var.services
+# Grant `roles/run.invoker` only to the agent invoker SA (created in the
+# agent-engine module). Agents impersonate this SA at runtime and present its
+# OIDC ID token to Cloud Run, so Cloud Run sees the impersonated SA as the
+# caller. `allUsers` is intentionally not granted: MCP services are unreachable
+# except by holders of an OIDC token for the invoker SA, regardless of
+# `private_networking`. Per-agent authorization is still enforced upstream at
+# the Agent Gateway via `roles/iap.egressor` (see scripts/grant_agent_mcp_egress.sh).
+#
+# When `invoker_sa_email` is null (e.g. the agent-engine module is disabled),
+# no binding is created and Cloud Run is unreachable until invoker is granted
+# out-of-band. There is no `allUsers` fallback by design.
+moved {
+  from = google_cloud_run_v2_service_iam_member.internal_lb_invoker
+  to   = google_cloud_run_v2_service_iam_member.agent_invoker
+}
+
+resource "google_cloud_run_v2_service_iam_member" "agent_invoker" {
+  for_each = var.invoker_sa_email != null ? var.services : {}
 
   project  = var.project_id
   location = var.region
   name     = google_cloud_run_v2_service.mcp[each.key].name
   role     = "roles/run.invoker"
-  member   = "allUsers"
+  member   = "serviceAccount:${var.invoker_sa_email}"
 }

--- a/demos/agent-gateway/terraform/modules/mcp-cloud-run/variables.tf
+++ b/demos/agent-gateway/terraform/modules/mcp-cloud-run/variables.tf
@@ -53,3 +53,9 @@ variable "private_networking" {
   type        = bool
   default     = true
 }
+
+variable "invoker_sa_email" {
+  description = "Email of the service account granted `roles/run.invoker` on every MCP Cloud Run service. Agents impersonate this SA (using `roles/iam.serviceAccountTokenCreator` granted on the agent identity in the agent-engine module) and present its OIDC ID token in the Authorization header. When null, no invoker binding is created and the services are unreachable until invoker is granted manually — this is the intended behavior when the agent-gateway demo is disabled."
+  type        = string
+  default     = null
+}

--- a/demos/agent-gateway/terraform/outputs.tf
+++ b/demos/agent-gateway/terraform/outputs.tf
@@ -88,6 +88,11 @@ output "mcp_service_account_emails" {
   value       = module.mcp_services.service_account_emails
 }
 
+output "agent_mcp_invoker_email" {
+  description = "Email of the SA agents impersonate when invoking MCP Cloud Run services. Pass to deploy_agent.py via --mcp-invoker-sa or $MCP_INVOKER_SA_EMAIL. Null when enable_agent_engine is false."
+  value       = var.enable_agent_engine ? module.agent_engine[0].agent_mcp_invoker_email : null
+}
+
 output "mcp_internal_dns_names" {
   description = "Map of MCP service key to its private DNS name (<service>.<domain>). Null when enable_cloud_run_private_networking = false (no MCP private zone is provisioned)."
   value = (


### PR DESCRIPTION
Replaces the allUsers run.invoker binding on MCP Cloud Run services with a binding scoped to a new agent-mcp-invoker SA. Agents impersonate this SA at runtime to mint OIDC ID tokens, which Cloud Run validates and accepts as the caller (Agent Identity principalSet members are not accepted as run.invoker directly today).

- agent-engine: create agent-mcp-invoker SA and grant the agent identity project-level roles/iam.serviceAccountTokenCreator
- mcp-cloud-run: bind run.invoker to invoker_sa_email instead of allUsers; use moved{} to preserve state from the prior resource address
- agent-registry-endpoints: add iamcredentials API to expected APIs
- mortgage-agent: build an httpx_client_factory that signs MCP HTTP calls with an OIDC token for the impersonated SA, and surface the SA email via --mcp-invoker-sa / MCP_INVOKER_SA_EMAIL