### PR TITLE
feat(agent-gateway): add authorization-debugging dashboard

### DIFF
--- a/demos/agent-gateway/.agents/skills/agent-platform-debugger/SKILL.md
+++ b/demos/agent-gateway/.agents/skills/agent-platform-debugger/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: agent-platform-debugger
+description: Debug Google Cloud Gemini Enterprise Agent Platform issues — Agent Gateway 403s, Agent Registry registration failures, Agent Identity / IAM denials, IAP egressor authorization, service-extensions delegated authz, hostname-permutation mismatches, authzPolicies / authzExtensions misconfig. Use whenever the user mentions agent gateway, agent registry, agent identity, IAP authorization for agents, ReasoningEngine 403s, "Egress request is not authorized", authzPolicies, authzExtensions, MCP server registration, or troubleshooting GCP agent platform requests — even if they don't explicitly say "debug" or name the product. Also trigger on terse symptom descriptions like "agent returning 403", "MCP tool not reachable", "authz extension denying" if there's any plausible Agent Platform context.
+---
+
+# Agent Platform Debugger
+
+Diagnose issues across the GCP Gemini Enterprise Agent Platform: Agent Gateway, Agent Registry (Agents / MCP Servers / Endpoints), Agent Identity, Policies, IAP-delegated authorization, and service extensions.
+
+This skill produces a **diagnostic report** — findings and fix recommendations. It does not apply fixes. The user owns the change.
+
+## When to use this skill
+
+Trigger when symptoms involve:
+
+- Agent → external API requests failing with 403, especially `Egress request is not authorized`
+- ReasoningEngine logs showing authz errors
+- Newly-registered endpoints / MCP servers / agents that "should work" but don't
+- Suspected IAP / IAM / IAM-principal-set issues for agent identities
+- Authz extension or authz policy debugging
+- Gateway routing / monitoring confusion
+- Anything where the user mentions Agent Gateway, Agent Registry, Agent Identity, or the Gemini Enterprise Agent Platform
+
+When *not* to use:
+
+- General GCP IAM debugging unrelated to the Agent Platform (use direct gcloud / IAM inspection)
+- Networking issues that don't involve the Agent Platform stack (e.g., raw VPC SC, plain Cloud Run auth)
+
+## Required context (gather first)
+
+Before doing anything else, pin down the basics. If the user hasn't supplied them, ask. Don't guess.
+
+| Item | Why it's needed |
+|---|---|
+| `PROJECT_ID` and `PROJECT_NUMBER` | Most API calls take one or the other; some take both |
+| `LOCATION` (region) | Registry, gateway, and IAM scope are regional. `global` is also valid for some resources |
+| `AGENT_ID` (ReasoningEngine ID) or runtime identifier | To filter agent logs |
+| `AGENT_GATEWAY_NAME` | To filter gateway logs |
+| Agent identity (service account email or principal-set ID) | To check IAM bindings |
+| Symptom: exact error text + when it started | Anchors hypothesis; "started after Terraform apply X" is gold |
+| The destination the agent was trying to reach | E.g. `aiplatform`, `discoveryengine`, an MCP server, another agent |
+
+If only some are known, proceed but call out the unknowns in the report.
+
+## Diagnostic flow
+
+This is a **process skill** — follow the steps in order. Most 403s resolve at step 2 or 4. Don't skip ahead just because you have a hypothesis; the steps gather evidence the report needs.
+
+```
+        ┌─────────────────────────────────────┐
+        │ 0. Establish the symptom & context  │
+        └────────────────┬────────────────────┘
+                         ▼
+        ┌─────────────────────────────────────┐
+        │ 1. Pull agent logs — confirm 403    │
+        └────────────────┬────────────────────┘
+                         ▼
+        ┌─────────────────────────────────────┐
+        │ 2. Pull gateway logs — find the     │
+        │    EXACT hostname being called      │
+        └────────────────┬────────────────────┘
+                         ▼
+        ┌─────────────────────────────────────┐
+        │ 3. Pull IAP logs — DRY_RUN or       │
+        │    enforced? Allow or deny?         │
+        └────────────────┬────────────────────┘
+                         ▼
+        ┌─────────────────────────────────────┐
+        │ 4. Is the EXACT hostname in the     │
+        │    registry (any of agents /        │
+        │    mcp-servers / endpoints)?        │
+        └────────┬────────────────────┬───────┘
+            no   │                yes │
+                 ▼                    ▼
+       ┌──────────────────┐   ┌─────────────────────────────┐
+       │ Root cause:      │   │ 5. Does the agent identity  │
+       │ unregistered     │   │    (or its principal set)   │
+       │ hostname permu-  │   │    have IAP egressor on     │
+       │ tation. Recommend│   │    the registered resource? │
+       │ registering all  │   └────────┬────────────────────┘
+       │ five forms.      │            │
+       └──────────────────┘            ▼
+                            ┌─────────────────────────────┐
+                            │ 6. Authz extension wired to │
+                            │    the gateway? Pointing at │
+                            │    IAP?                     │
+                            └────────┬────────────────────┘
+                                     ▼
+                            ┌─────────────────────────────┐
+                            │ 7. Agent identity baseline  │
+                            │    roles (Vertex User,      │
+                            │    Registry Viewer, logs)   │
+                            └────────┬────────────────────┘
+                                     ▼
+                            ┌─────────────────────────────┐
+                            │ 8. PrincipalSet flakiness?  │
+                            │    Recommend 1:1 binding    │
+                            │    test                     │
+                            └─────────────────────────────┘
+```
+
+The exact log queries, gcloud commands, and curl invocations live in `references/field-manual.md`. Read that file when you reach each step — it has the copy-pasteable commands and explains what each output means.
+
+## Tools to use
+
+The skill assumes the agent has access to:
+
+- **`mcp__gcloud__run_gcloud_command`** — for `gcloud` invocations (registry listing, authz-extensions describe, IAM, project lookup).
+- **`mcp__gcloud-observability__list_log_entries`** — for the structured log queries in steps 1, 2, 3.
+- **`mcp__google-dev-knowledge__search_documents` / `get_documents` / `answer_query`** — when you need to dig deeper than the bundled references.
+- **`Bash`** — for `curl` calls to the IAP / NetworkSecurity / NetworkServices / ServiceExtensions APIs (the field manual has the exact invocations). Do *not* ask the user to run these; run them yourself when reasonable. Surface the user-runnable form in the report so they can re-run after a fix.
+
+Run independent log queries in parallel — the agent log, gateway log, and IAP log filters in steps 1-3 don't depend on each other.
+
+## How to use the references
+
+The `references/` folder is layered:
+
+- **`field-manual.md`** — read this first on every invocation. It's the operational core: hostname permutations, log queries (with the exact filters and which fields to project on), gcloud commands, curl IAM-policy fetches, the layered default-deny model (registry → gateway → authz extension → IAP/IAM → PAB), and the quick-reference step list. Most diagnoses can be done with just this file.
+- **`known-issues.md`** — read when the symptom matches a recurring pattern (ReasoningEngine startup failures, missing `authz_policy` targeting the gateway, IAP-enforced startup blocks, PAB overriding IAM, gateway proxy denials with no IAP entry). Indexed by symptom; faster than the full diagnostic flow when you recognize the failure mode.
+- **`agent-gateway.md`** — when the gateway itself is the suspect (routing, service-extension setup, monitoring fields).
+- **`policies.md`** — when the question is about IAM modeling (PrincipalSet vs Principal, role layering, authzPolicies, PAB).
+- **`agent-registry.md`** — when registration mechanics are unclear (which resource type to use, hostname-permutation registration patterns, how listing/describing works).
+- **`agent-identity.md`** — when the question is about *who* the agent is (token format, identity assignment, baseline roles).
+
+Read the smallest set that answers the question. Don't preload everything.
+
+## Output report
+
+Always produce a structured report. Use this template exactly — predictability matters because the user may want to share or grep these reports.
+
+```markdown
+# Agent Platform Diagnostic — <one-line summary>
+
+## Context
+- Project: <id> (<number>)
+- Location: <region>
+- Agent: <agent_id / name>
+- Gateway: <gateway_name>
+- Symptom: <exact error message and when it started>
+
+## Evidence gathered
+- Agent log query: <filter, brief summary of matches>
+- Gateway log query: <filter, exact failing hostname found>
+- IAP log query: <filter, decision + enforcement mode>
+- Registry state: <relevant entries, IAM bindings>
+- (any other tool output that mattered)
+
+## Root cause hypothesis
+<single most likely cause, stated plainly. If multiple, rank them.>
+
+## Why this fits the evidence
+<brief — connect the dots. Show which evidence rules in / rules out the hypothesis.>
+
+## Recommended fix
+<concrete actions in order. Show exact gcloud / curl / Terraform changes the user can run. If the fix is in the user's repo (Terraform), point at file:line.>
+
+## What to verify after the fix
+<the queries to re-run to confirm resolution.>
+
+## Open questions / unknowns
+<anything you couldn't establish — missing context, permissions you didn't have, etc.>
+```
+
+If you ran commands and the output is long, include only the *signal* in the report, not raw blobs. Paste the exact filter string so the user can re-run.
+
+## Principles
+
+- **Hostname mismatch is the #1 cause.** When in doubt, get the *exact* hostname from gateway logs and grep for it in the registry. The official docs say "register the API"; in practice you have to register five hostname permutations (six with PSC). Also watch for `unregisteredResource` in IAP audit-log labels — that's the unambiguous "hostname not in registry" signal.
+- **Default-deny is the model with multiple layers.** Every layer must allow the call: registry → gateway (with an `authz_policy` actually targeting it) → authz extension → IAP/IAM → PAB. A missing entry or restriction at *any* layer produces the same 403 — your job is to find which layer. Note: the gateway's underlying egress proxy (a Google-managed Secure Web Proxy instance) can also deny calls before IAP runs; those denials show up only in load-balancer logs, not IAP audit logs.
+- **PAB beats IAM Allow.** A correct `roles/iap.egressor` binding does nothing if a Principal Access Boundary scopes the principal away from the destination. Always rule out PAB before iterating on IAM bindings.
+- **DRY_RUN changes everything.** If IAP is in dry-run, denials are logged but not enforced — so the real denial is somewhere else (often the gateway's underlying egress proxy, or the destination service itself). Don't waste time on IAM bindings if the IAP layer isn't actually enforcing.
+- **The role is `roles/iap.egressor`.** Not `iap.tunnelResourceAccessor`, not `iap.httpsResourceAccessor`, not `iap.tunnelDestGroupUser`. Those are different IAP roles for different surfaces. The IAP authz check looks for `iap.webServiceVersions.egressViaIAP`, which only `roles/iap.egressor` grants on the Agent Gateway path.
+- **Read evidence, don't assume.** Pull logs first. Don't recommend "grant role X" without showing that role X is the missing one.
+- **Cite exact resource names in the report.** Service account emails, role IDs (`roles/iap.tunnelResourceAccessor`), and resource paths should appear verbatim — they're what the user needs to act on.
+- **Stay in diagnosis mode.** Don't apply Terraform changes or run destructive gcloud commands. Read-only inspection only. The report is the deliverable.

--- a/demos/agent-gateway/.agents/skills/agent-platform-debugger/references/agent-gateway.md
+++ b/demos/agent-gateway/.agents/skills/agent-platform-debugger/references/agent-gateway.md
@@ -1,0 +1,492 @@
+# Agent Gateway — Debugging Reference
+
+Curated from Google Cloud's Gemini Enterprise Agent Platform docs (Private Preview, sourced May 2026). Focused on what a debugger needs to triage failed requests through Agent Gateway.
+
+---
+
+## TL;DR for debugging
+
+- Agent Gateway is a **regional** networking resource (`networkservices.googleapis.com/Gateway`) that intercepts MCP traffic in one of two modes: `CLIENT_TO_AGENT` (ingress) or `AGENT_TO_ANYWHERE` (egress). One gateway can only be one mode.
+- Logs live under monitored resource type **`networkservices.googleapis.com/Gateway`** with labels `location` and `gateway_name`. The interesting payload is `jsonPayload.agentGatewayInfo`, which contains `mcpInfo` (e.g. `tools/call`, `tools/list`) and `agentRegistryResource` (the matched MCP server / agent / endpoint URN).
+- Authorization is delegated through **service extensions** attached via `networksecurity.authzPolicies`. Two profile types: `REQUEST_AUTHZ` (headers only) and `CONTENT_AUTHZ` (request/response bodies, requires `ext_proc` `FULL_DUPLEX_STREAMED`).
+- IAP authorization extension uses the metadata flag **`iamEnforcementMode`** with values `DRY_RUN` (audit only, requests still flow) or omitted (enforced). Logs are produced in both modes — if a request "should be denied but isn't", check this flag first.
+- The gateway service account for cross-project calls (Model Armor, DNS peering) is **`service-PROJECT_NUMBER@gcp-sa-dep.iam.gserviceaccount.com`**.
+- **Hard limit: max 4 custom authorization policies per Agent Gateway.** Policies with the same profile have **undefined execution order** — don't rely on ordering.
+- Default-deny posture for unregistered MCP servers/tools — a 4xx may simply mean the target isn't in Agent Registry for that region.
+- Agents and the gateway must be in the **same project and region** for Agent Runtime; Gemini Enterprise uses the global Agent Registry path.
+- Cloud Trace only sends spans for `tools/call` (other MCP methods don't produce spans). W3C `traceparent` only — `X-Cloud-Trace-Context` is **not** supported.
+- VPC Service Controls is **not** compatible. Authorization conditions only apply to MCP — non-MCP agentic protocols won't get policy enforcement.
+
+---
+
+## 1. What Agent Gateway is
+
+Agent Gateway is the networking entry/exit point of the Gemini Enterprise Agent Platform. It secures and governs:
+
+- **Client-to-Agent (ingress):** External clients reaching agents/tools on Google Cloud.
+- **Agent-to-Anywhere (egress):** Agents on Google Cloud reaching external services, APIs, MCP servers, or other agents.
+
+### Where it sits
+
+- **Regional** resource within a single project.
+- A single gateway is bound to one `governedAccessPath` — either `CLIENT_TO_AGENT` or `AGENT_TO_ANYWHERE`. They are mutually exclusive.
+- "A single Agent Gateway cannot simultaneously support both Gemini Enterprise and Agent Runtime integrations" — deploy separate gateways per integration.
+
+### Runtime support matrix
+
+| Runtime | Ingress | Egress | Region rule |
+|---|---|---|---|
+| Agent Runtime | yes | yes | Agents must be in same project + region as gateway |
+| Gemini Enterprise | no | yes | Gateway placement must align with multi-region setup |
+
+### What it integrates with
+
+- **Agent Registry** — gateway looks up metadata to enforce policies. Agents must be registered in the matching region (or `global` for Gemini Enterprise).
+- **Agent Identity** — SPIFFE IDs, mTLS, DPoP (Demonstration of Proof-of-Possession).
+- **IAP** (Identity-Aware Proxy) — primary IAM enforcement layer; enabled by default for egress.
+- **Service Extensions** — delegation to external authz engines or Model Armor.
+- **Load Balancer Authorization Policies** — fine-grained MCP-attribute access control.
+- **Model Armor** — runtime prompt-injection / data-leak defense.
+- **Cloud Logging / Cloud Trace** — observability.
+
+### Key resource types
+
+| Type | Purpose |
+|---|---|
+| `networkservices.agentGateways` | The gateway itself |
+| `networksecurity.authzPolicies` | Attaches authorization policies to a gateway |
+| `networkservices.authzExtensions` | Custom or Google-managed authorization callouts |
+| `compute.networkAttachments` | PSC connectivity for egress to private networks |
+| Model Armor templates | Content policies (used via authz extension) |
+
+### Limitations to remember while debugging
+
+- MCP-only authorization conditions; other agent protocols won't be filtered.
+- Gemini Enterprise has no Client-to-Agent support.
+- **VPC Service Controls is incompatible.**
+- Default-deny for any MCP server / tool not registered in Agent Registry (unless explicitly allowed).
+
+Source: <https://docs.cloud.google.com/gemini-enterprise-agent-platform/govern/gateways/agent-gateway-overview>
+
+---
+
+## 2. Setup — what to verify when something is missing
+
+When a request fails, walk this checklist to make sure the gateway and its dependencies were assembled correctly.
+
+### 2.1 Required APIs
+
+- `compute.googleapis.com`
+- `networksecurity.googleapis.com`
+- `networkservices.googleapis.com`
+- `modelarmor.googleapis.com` (optional; only if Model Armor extensions are attached)
+
+### 2.2 Required IAM permissions on the deployer
+
+Gateway management:
+- `networkservices.agentGateways.{create,delete,get,list,update,use}`
+
+Authorization extensions and policies:
+- `networkservices.authzExtensions.{create,delete,get,list,update,use}`
+- `networksecurity.authzPolicies.{create,delete,get,list}`
+- `networksecurity.operations.get`
+
+Supporting:
+- `compute.networkAttachments.list`
+- `compute.regions.list`
+- `modelarmor.templates.list`
+
+The permission to **attach** an authz policy to a deployed gateway is `agentGateway.use` on the target gateway.
+
+### 2.3 Create the gateway (egress example)
+
+`my-agent-gateway.yaml`:
+
+```yaml
+name: AGENT_GATEWAY_NAME
+protocols:
+  - MCP
+googleManaged:
+  governedAccessPath: AGENT_TO_ANYWHERE
+registries:
+  - AGENT_REGISTRY_PATH
+```
+
+`AGENT_REGISTRY_PATH` values:
+
+- Agent Runtime (regional): `//agentregistry.googleapis.com/projects/PROJECT_ID/locations/REGION`
+- Gemini Enterprise (global): `//agentregistry.googleapis.com/projects/PROJECT_ID/locations/global`
+
+Create or update:
+
+```bash
+gcloud alpha network-services agent-gateways import AGENT_GATEWAY_NAME \
+  --source="my-agent-gateway.yaml" \
+  --location=LOCATION
+```
+
+### 2.4 Ingress variant
+
+```yaml
+name: AGENT_GATEWAY_NAME
+protocols:
+  - MCP
+googleManaged:
+  governedAccessPath: CLIENT_TO_AGENT
+```
+
+### 2.5 Optional VPC connectivity (egress)
+
+PSC requirements:
+
+- A Private Service Connect network attachment, **minimum `/28` subnet**.
+- Subnet must lie within RFC1918: `10.0.0.0/8`, `172.16.0.0/12`, or `192.168.0.0/16`.
+- Avoid these reserved ranges: `10.0.0.0/24`, `10.0.1.0/24`, `10.0.2.0/24`.
+
+YAML:
+
+```yaml
+networkConfig:
+  egress:
+    networkAttachment: PSC_NETWORK_ATTACHMENT_URI
+  dnsPeeringConfig:
+    domains:
+      - DOMAIN_NAME
+    targetProject: TARGET_PROJECT_ID
+    targetNetwork: TARGET_NETWORK_URI
+```
+
+For DNS peering across a Shared VPC, the gateway service account needs `roles/dns.peer` on the target project:
+
+```bash
+gcloud alpha projects add-iam-policy-binding TARGET_PROJECT_ID \
+  --member=serviceAccount:service-GATEWAY_PROJECT_NUMBER@gcp-sa-dep.iam.gserviceaccount.com \
+  --role=roles/dns.peer
+```
+
+### 2.6 Order of operations
+
+1. Enable APIs.
+2. Create / register agents in Agent Registry (same region; or `global` for Gemini Enterprise).
+3. Create the gateway resource.
+4. (Optional) Configure PSC network attachment and DNS peering.
+5. Create authorization extensions (`authzExtensions`).
+6. Attach authorization policies (`authzPolicies`) targeting the gateway.
+7. Route runtime / Gemini Enterprise traffic through the gateway.
+
+If a stage was skipped, requests will typically fail with a default-deny or an unmatched-route response.
+
+Source: <https://docs.cloud.google.com/gemini-enterprise-agent-platform/govern/gateways/set-up-agent-gateway>
+
+---
+
+## 3. Delegated authorization — service extensions contract
+
+Authorization is offloaded to **authorization extensions** that the gateway calls over gRPC for each request.
+
+### 3.1 Policy profiles
+
+| Profile | What it sees | Use case |
+|---|---|---|
+| `REQUEST_AUTHZ` | HTTP request headers only | IAM checks, IAP, fast header-based rules |
+| `CONTENT_AUTHZ` | Full request and response payloads | Model Armor, content scanning |
+
+`CONTENT_AUTHZ` extensions **must** support `ext_proc` in `FULL_DUPLEX_STREAMED` mode. If the extension doesn't, requests will fail.
+
+### 3.2 The `iamEnforcementMode` flag (IAP)
+
+Configured on the IAP authorization extension:
+
+```yaml
+name: my-iap-request-authz-ext
+service: iap.googleapis.com
+failOpen: true
+timeout: 1s
+metadata:
+  iamEnforcementMode: "DRY_RUN"   # audit-only; remove or change to enforce
+```
+
+Behaviors:
+
+- `DRY_RUN` — IAM policy is evaluated and **logged**, but the request is **not blocked** even if it would have been denied. Use this to verify policy without breaking traffic.
+- Field omitted — enforced mode (default). Failures are blocked.
+
+**Debugging implication:** If "denied" requests are still succeeding, `iamEnforcementMode: DRY_RUN` is almost certainly set on the extension. Inspect the `authzExtension` resource directly.
+
+### 3.3 Other extension patterns
+
+Model Armor (CONTENT_AUTHZ):
+
+```yaml
+name: my-ma-content-authz-ext
+service: modelarmor.LOCATION.rep.googleapis.com
+metadata:
+  model_armor_settings: '[{
+    "response_template_id": "projects/MODEL_ARMOR_PROJECT_ID/...",
+    "request_template_id":  "projects/MODEL_ARMOR_PROJECT_ID/..."
+  }]'
+failOpen: true
+timeout: 1s
+```
+
+Custom FQDN extension:
+
+```yaml
+name: my-custom-authz-ext
+service: mycustomauthz.internal.net
+failOpen: true
+timeout: 1s
+wireFormat: EXT_AUTHZ_GRPC
+```
+
+`failOpen: true` means callout errors **let the request through**. If a backend is broken but traffic is still flowing, the policy is fail-open — that masks real failures.
+
+Custom extensions targeted at FQDNs use **HTTP/2 over TLS on port 443 with no server-cert validation**. Cert misconfiguration won't cause errors but is a security smell.
+
+### 3.4 Attaching policies
+
+`REQUEST_AUTHZ`:
+
+```yaml
+name: my-iap-request-authz-policy
+target:
+  resources:
+    - "projects/PROJECT_ID/locations/LOCATION/agentGateways/AGENT_GATEWAY_NAME"
+policyProfile: REQUEST_AUTHZ
+action: CUSTOM
+customProvider:
+  authzExtension:
+    resources:
+      - "projects/PROJECT_ID/locations/LOCATION/authzExtensions/my-iap-request-authz-ext"
+```
+
+`CONTENT_AUTHZ` is the same shape with `policyProfile: CONTENT_AUTHZ`.
+
+### 3.5 MCP method-scoped allow rules
+
+```yaml
+name: my-authz-policy-restrict-tools
+target:
+  resources:
+    - "projects/PROJECT_ID/locations/LOCATION/agentGateways/AGENT_GATEWAY_NAME"
+policyProfile: REQUEST_AUTHZ
+httpRules:
+  - to:
+      operations:
+        - mcp:
+            baseProtocolMethodsOption: MATCH_BASE_PROTOCOL_METHODS
+            methods:
+              - name: "tools/list"
+              - name: "tools/call"
+                params:
+                  - exact: "get_weather"
+```
+
+**Critical:** When using `ALLOW` policies for MCP, set `baseProtocolMethodsOption: MATCH_BASE_PROTOCOL_METHODS` or you'll silently break the core MCP RPCs (`initialize`, `logging`, `completion`, `notifications`, `ping`).
+
+### 3.6 Cross-project Model Armor IAM
+
+Gateway service account: `service-PROJECT_NUMBER@gcp-sa-dep.iam.gserviceaccount.com`
+
+| Where | Role |
+|---|---|
+| Gateway project | `roles/modelarmor.calloutUser` |
+| Gateway project | `roles/serviceusage.serviceUsageConsumer` |
+| Model Armor project | `roles/modelarmor.user` |
+
+### 3.7 Hard limits and gotchas
+
+- **Max 4 custom authorization policies per Agent Gateway.**
+- Multiple policies sharing the same profile have **undefined execution order**.
+- `CONTENT_AUTHZ` requires `ext_proc` `FULL_DUPLEX_STREAMED`.
+- Cross-project Model Armor needs all three IAM bindings above; missing any one causes silent extension failures (and `failOpen: true` masks them).
+
+Source: <https://docs.cloud.google.com/gemini-enterprise-agent-platform/govern/gateways/delegate-authorization>
+
+---
+
+## 4. Logging and monitoring
+
+### 4.1 Monitored resource
+
+```
+resource.type   = "networkservices.googleapis.com/Gateway"
+resource.labels.location      = REGION
+resource.labels.gateway_name  = AGENT_GATEWAY_NAME
+```
+
+Logs are produced for **all** traffic, including dry-run mode requests.
+
+### 4.2 Standard log filter
+
+```
+resource.type="networkservices.googleapis.com/Gateway"
+resource.labels.location="REGION"
+resource.labels.gateway_name="AGENT_GATEWAY_NAME"
+```
+
+`gcloud` equivalent:
+
+```bash
+gcloud logging read \
+  'resource.type="networkservices.googleapis.com/Gateway"
+   resource.labels.location="us-central1"
+   resource.labels.gateway_name="my-gateway"' \
+  --limit=50 --format=json
+```
+
+### 4.3 Log entry fields
+
+Required `LogEntry` fields:
+
+| Field | Notes |
+|---|---|
+| `severity`, `insertId`, `timestamp`, `receiveTimestamp` | standard |
+| `trace`, `traceSampled`, `logName` | standard |
+| `httpRequest` | standard `HttpRequest` proto |
+| `resource` | the `MonitoredResource` (type above) |
+| `jsonPayload` | gateway-specific payload |
+
+`jsonPayload` contents:
+
+| Field | Description |
+|---|---|
+| `agentGatewayInfo` | Wrapper for gateway-specific request info |
+| `agentGatewayInfo.mcpInfo` | The MCP method (e.g. `tools/list`, `tools/call`) and primary parameter (e.g. tool name for `tools/call`) |
+| `agentGatewayInfo.agentRegistryResource` | Agent Registry resource name of the matched MCP server / agent / endpoint |
+
+### 4.4 Useful log filters for debugging
+
+Failed requests only:
+
+```
+resource.type="networkservices.googleapis.com/Gateway"
+resource.labels.gateway_name="AGENT_GATEWAY_NAME"
+httpRequest.status>=400
+```
+
+Specific MCP method:
+
+```
+resource.type="networkservices.googleapis.com/Gateway"
+jsonPayload.agentGatewayInfo.mcpInfo.method="tools/call"
+```
+
+Specific tool name (when method is `tools/call`):
+
+```
+resource.type="networkservices.googleapis.com/Gateway"
+jsonPayload.agentGatewayInfo.mcpInfo.method="tools/call"
+jsonPayload.agentGatewayInfo.mcpInfo.params:"get_weather"
+```
+
+Requests against a specific registered agent / MCP server:
+
+```
+resource.type="networkservices.googleapis.com/Gateway"
+jsonPayload.agentGatewayInfo.agentRegistryResource:"my-mcp-server"
+```
+
+### 4.5 Metrics
+
+Agent Gateway exports **Service Extensions** metrics to Cloud Monitoring. When triaging extension callout failures (timeouts, 5xx from the extension, fail-open behavior), use the same metrics described in Cloud Load Balancing callouts: <https://docs.cloud.google.com/service-extensions/docs/monitor-lb-callouts#monitoring_metrics_for_callouts>
+
+### 4.6 Cloud Trace
+
+Cloud Trace covers MCP tool calls but with caveats:
+
+- Only `tools/call` operations produce spans. `tools/list`, `initialize`, etc. **don't**.
+- Only **W3C `traceparent`** is supported. The legacy `X-Cloud-Trace-Context` header is ignored.
+- Unauthenticated, unauthorized, or policy-rejected requests may not appear in trace samples.
+
+Trace can be triggered by either an HTTP `traceparent` header or by setting `params._meta.traceparent` in the MCP body, with the W3C sampled flag set to `1`.
+
+Resource attributes on MCP spans:
+
+| Attribute | Description |
+|---|---|
+| `cloud.account.id` | Billing project ID |
+| `cloud.provider` | always `gcp` |
+| `gcp.mcp.server.id` | URN of the MCP server |
+| `gcp.project_id` | Project where telemetry is sent |
+
+Span attributes:
+
+| Attribute | Description |
+|---|---|
+| `error.message` | Error message on failure |
+| `error.type` | Low-cardinality error type |
+| `gen_ai.operation.name` | Always `execute_tool` for MCP |
+| `gen_ai.tool.name` | Invoked tool name |
+| `jsonrpc.protocol.version` | JSON-RPC version |
+| `jsonrpc.request.id` | Unique JSON-RPC invocation ID |
+| `mcp.method.name` | e.g. `tools/call` |
+| `mcp.protocol.version` | MCP version |
+
+Scope attribute:
+
+| Attribute | Description |
+|---|---|
+| `gcp.server.service` | MCP server service name (e.g. `bigquery.googleapis.com`) |
+
+Source: <https://docs.cloud.google.com/gemini-enterprise-agent-platform/govern/gateways/monitor-agent-gateway>
+Trace details: <https://docs.cloud.google.com/mcp/monitor-mcp-tool-use-with-cloud-trace>
+
+---
+
+## 5. Common failure modes and where to look
+
+| Symptom | Likely cause | First place to look |
+|---|---|---|
+| All requests pass even after attaching a deny/IAP policy | Extension has `iamEnforcementMode: "DRY_RUN"` | The `authzExtension` resource metadata |
+| Extension errors but traffic keeps flowing | `failOpen: true` on the extension | The `authzExtension` definition; Service Extensions metrics |
+| `tools/list` works but `tools/call` for a specific tool fails | Tool not in Agent Registry, or restricted by an MCP method-scoped policy | Agent Registry; `httpRules.to.operations.mcp.methods` in `authzPolicies` |
+| Core MCP methods (`initialize`, `ping`, `notifications`) break after adding an ALLOW policy | Missing `baseProtocolMethodsOption: MATCH_BASE_PROTOCOL_METHODS` | The `httpRules` block of the policy |
+| Cross-project Model Armor extension fails silently | Missing one of `roles/modelarmor.calloutUser`, `roles/serviceusage.serviceUsageConsumer` (gateway project) or `roles/modelarmor.user` (Model Armor project) on `service-PROJECT_NUMBER@gcp-sa-dep.iam.gserviceaccount.com` | IAM bindings in both projects |
+| DNS resolution for private targets fails (egress) | Missing `roles/dns.peer` for the gateway service account on Shared VPC host project, or PSC subnet too small / overlapping reserved ranges | `dnsPeeringConfig`; PSC network attachment |
+| Requests denied with no log entry of the policy | Default-deny because the agent / MCP server isn't in Agent Registry for that region | Agent Registry registration for the matching region |
+| Gateway accepts neither ingress nor expected egress | `governedAccessPath` is the wrong mode (ingress vs egress); modes are mutually exclusive | YAML `googleManaged.governedAccessPath` |
+| New policy has no effect | Already 4 custom authz policies attached (the cap), or two same-profile policies in undefined order | List `authzPolicies` for the gateway |
+| Can't see request bodies in logs / can't apply content rules | Using `REQUEST_AUTHZ` profile (headers only); needs `CONTENT_AUTHZ` extension that supports `ext_proc` `FULL_DUPLEX_STREAMED` | Policy profile and extension capabilities |
+| Trace headers don't propagate | Sending `X-Cloud-Trace-Context`; only W3C `traceparent` is honored for MCP | Client trace header |
+| No spans for `tools/list` | Expected — only `tools/call` produces spans | n/a |
+| Calls fail in a perimeter project | VPC Service Controls is incompatible with Agent Gateway | Move out of perimeter or grant ingress/egress rules accordingly |
+
+---
+
+## 6. Quick gcloud cheatsheet
+
+```bash
+# Inspect the gateway
+gcloud alpha network-services agent-gateways describe AGENT_GATEWAY_NAME \
+  --location=LOCATION
+
+# List authorization extensions
+gcloud alpha network-services authz-extensions list --location=LOCATION
+
+# List authorization policies
+gcloud alpha network-security authz-policies list --location=LOCATION
+
+# Pull recent gateway logs
+gcloud logging read \
+  'resource.type="networkservices.googleapis.com/Gateway"
+   resource.labels.gateway_name="AGENT_GATEWAY_NAME"' \
+  --limit=20 --freshness=1h --format=json
+
+# Filter on errors only
+gcloud logging read \
+  'resource.type="networkservices.googleapis.com/Gateway"
+   resource.labels.gateway_name="AGENT_GATEWAY_NAME"
+   httpRequest.status>=400' \
+  --limit=50 --freshness=1h
+```
+
+---
+
+## Source URLs
+
+- Overview: <https://docs.cloud.google.com/gemini-enterprise-agent-platform/govern/gateways/agent-gateway-overview>
+- Setup: <https://docs.cloud.google.com/gemini-enterprise-agent-platform/govern/gateways/set-up-agent-gateway>
+- Delegate authorization: <https://docs.cloud.google.com/gemini-enterprise-agent-platform/govern/gateways/delegate-authorization>
+- Monitor: <https://docs.cloud.google.com/gemini-enterprise-agent-platform/govern/gateways/monitor-agent-gateway>
+- MCP + Cloud Trace (referenced for trace fields): <https://docs.cloud.google.com/mcp/monitor-mcp-tool-use-with-cloud-trace>

--- a/demos/agent-gateway/.agents/skills/agent-platform-debugger/references/agent-identity.md
+++ b/demos/agent-gateway/.agents/skills/agent-platform-debugger/references/agent-identity.md
@@ -1,0 +1,514 @@
+# Agent Identity — Debugging Reference
+
+Reference for diagnosing "who is this request from?" issues on Gemini Enterprise
+Agent Platform / Vertex AI Agent Engine (Reasoning Engines).
+
+Primary source:
+<https://docs.cloud.google.com/gemini-enterprise-agent-platform/govern/agent-identity-overview>
+(mirrored at <https://docs.cloud.google.com/iam/docs/agent-identity-overview>)
+
+---
+
+## TL;DR for debugging
+
+- An "agent identity" is a SPIFFE-based, per-agent principal — not a service
+  account. It is bound 1:1 to the runtime resource (e.g. a single
+  `reasoningEngines/<id>`).
+- The runtime can use one of three identity modes (`identityType` enum on
+  `ReasoningEngineSpec`): `IDENTITY_TYPE_UNSPECIFIED` (legacy),
+  `SERVICE_ACCOUNT`, or `AGENT_IDENTITY`. Default is service-account behavior.
+- The actual identity in use at runtime is exposed as
+  `spec.effectiveIdentity` on the ReasoningEngine resource. Read this first.
+- IAM bindings use `principal://...` (single agent) and `principalSet://...`
+  (group of agents in a trust domain / project / org). The trust domain is
+  per-org or per-orgless-project and looks like
+  `agents.global.org-<ORG_ID>.system.id.goog` or
+  `agents.global.project-<PROJECT_NUMBER>.system.id.goog`.
+- The Agent Engine SDK uses Application Default Credentials, which on the
+  runtime automatically pull the Agent Identity token from the metadata
+  server — no explicit code is required for it to take effect.
+- A new agent gets `roles/aiplatform.agentDefaultAccess` and
+  `roles/aiplatform.agentContextEditor` only. For most real-world tools you
+  must additionally grant: `roles/aiplatform.expressUser`,
+  `roles/serviceusage.serviceUsageConsumer`, `roles/browser`,
+  `roles/logging.logWriter`, `roles/monitoring.metricWriter`,
+  `roles/cloudapiregistry.viewer`.
+- A `401 UNAUTHENTICATED` from a Google Cloud API in an Agent-Identity-enabled
+  runtime almost always means Context-Aware Access (mTLS / DPoP token-binding)
+  is rejecting the call — not an IAM permission problem. Check binding /
+  egress path before adding roles.
+- Service-account mode default is the Google-managed
+  `service-<PROJECT_NUMBER>@gcp-sa-aiplatform-re.iam.gserviceaccount.com`
+  (role: `roles/aiplatform.reasoningEngineServiceAgent`). To see it in the
+  IAM page you must check "Include Google-provided role grants".
+- Logs show *both* the agent SPIFFE identity and the end-user identity when an
+  agent is acting on behalf of a user; only the agent identity when acting on
+  its own authority.
+
+---
+
+## What "agent identity" means (vs service account, vs principal set)
+
+Source: <https://docs.cloud.google.com/iam/docs/agent-identity-overview>
+
+Agent Identity provides cryptographic, SPIFFE-based identities for agents so
+they can authenticate to MCP servers, Google Cloud APIs, the Agent Gateway,
+and other agents.
+
+Compared to service accounts:
+
+| Property | Service account | Agent Identity |
+|---|---|---|
+| Shared across workloads | Yes (default) | No — 1 per agent resource |
+| Impersonable by other agents | Yes (with role) | No |
+| Long-lived keys allowed | Yes | No (system-managed only) |
+| Token binding | No | Yes (X.509-bound, DPoP) |
+| Identity scope | Project | Tied to runtime resource URI |
+
+Three things commonly get conflated when debugging — keep them distinct:
+
+1. **Service account** — `name@project.iam.gserviceaccount.com`. Used when
+   `identityType` is unset or `SERVICE_ACCOUNT`. Granted via
+   `serviceAccount:` IAM member.
+2. **Agent identity (single agent)** — a SPIFFE principal bound to one
+   ReasoningEngine. Granted via `principal://<TRUST_DOMAIN>/resources/...`.
+3. **Principal set** — a group of agent identities (all agents in a project,
+   trust domain, or org). Granted via `principalSet://<TRUST_DOMAIN>/...`.
+   Used to apply common roles (logging, quota, model access) to many agents
+   at once without per-agent bindings.
+
+---
+
+## Identity format and trust domains
+
+Source: <https://docs.cloud.google.com/iam/docs/agent-identity-overview>
+
+SPIFFE ID (used internally / inside the X.509 SAN):
+
+```
+spiffe://<TRUST_DOMAIN>/resources/<SERVICE>/<RESOURCE_PATH>
+```
+
+IAM principal identifier (what you put in policies):
+
+```
+principal://<TRUST_DOMAIN>/resources/<SERVICE>/<RESOURCE_PATH>
+```
+
+Concrete examples:
+
+- Vertex AI Agent Engine:
+  `principal://agents.global.org-123456789012.system.id.goog/resources/aiplatform/projects/9876543210/locations/us-central1/reasoningEngines/my-test-agent`
+- Gemini Enterprise:
+  `principal://agents.global.org-123456789012.system.id.goog/resources/discoveryengine/projects/9876543210/locations/global/collections/default_collection/engines/my-test-agent`
+
+Trust domain (auto-provisioned when the Agent Platform API is first enabled):
+
+- Org present: `agents.global.org-<ORGANIZATION_ID>.system.id.goog`
+- Orgless project: `agents.global.project-<PROJECT_NUMBER>.system.id.goog`
+
+Source: <https://docs.cloud.google.com/gemini-enterprise-agent-platform/scale/runtime/agent-identity>
+
+---
+
+## Principal set forms (for IAM policy debugging)
+
+Source: <https://docs.cloud.google.com/iam/docs/principal-identifiers>
+
+| Scope | Identifier |
+|---|---|
+| Single agent | `principal://<TRUST_DOMAIN>/resources/<SERVICE>/<RESOURCE_PATH>` |
+| All agents in a trust domain | `principalSet://<TRUST_DOMAIN>/*` |
+| All agents in a project | `principalSet://<TRUST_DOMAIN>/attribute.platformContainer/aiplatform/projects/<PROJECT_NUMBER>` |
+| All agents in an org | `principalSet://agents.global.org-<ORG_ID>.system.id.goog/attribute.platform/aiplatform` |
+| DIY agents (workload identity pool) | `principal://iam.googleapis.com/projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/<POOL>/subject/ns/<NS>/sa/<SA>` |
+
+Tips when debugging:
+
+- If you see `principalSet://...attribute.platformContainer/aiplatform/projects/<num>`
+  in a binding, that is *all* agents in that project. A binding here grants
+  every agent in the project the role — useful for shared roles
+  (logging/quota), bad for sensitive resources.
+- The `attribute.platform/aiplatform` set covers an *entire org*.
+
+---
+
+## How identities are created and bound to ReasoningEngines
+
+Source: <https://docs.cloud.google.com/gemini-enterprise-agent-platform/scale/runtime/agent-identity>
+Source: <https://docs.cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1beta1/projects.locations.reasoningEngines>
+
+The `IdentityType` enum on `ReasoningEngineSpec`:
+
+- `IDENTITY_TYPE_UNSPECIFIED` — same as `SERVICE_ACCOUNT`. Uses the
+  `serviceAccount` field if set, else default Reasoning Engine Service Agent.
+- `SERVICE_ACCOUNT` — same behavior as above; explicit.
+- `AGENT_IDENTITY` — uses Agent Identity. The `serviceAccount` field **must
+  not be set** when this is selected.
+
+### Create with Agent Identity (Python SDK)
+
+```python
+import vertexai
+from vertexai import types
+from vertexai.agent_engines import AdkApp
+
+# v1beta1 is required for Agent Identity support
+client = vertexai.Client(
+    project=PROJECT_ID,
+    location=LOCATION,
+    http_options=dict(api_version="v1beta1"),
+)
+
+remote_app = client.agent_engines.create(
+    agent=AdkApp(agent=agent),
+    config={
+        "display_name": "running-agent-with-identity",
+        "identity_type": types.IdentityType.AGENT_IDENTITY,
+        "requirements": ["google-cloud-aiplatform[adk,agent_engines]"],
+        "staging_bucket": f"gs://{BUCKET_NAME}",
+    },
+)
+print(f"Effective Identity: {remote_app.api_resource.spec.effective_identity}")
+```
+
+### Create identity-only (no agent code yet) so you can pre-grant IAM
+
+```python
+remote_app = client.agent_engines.create(
+    config={"identity_type": types.IdentityType.AGENT_IDENTITY},
+)
+# Later: agent_engines.update(...) to add code.
+```
+
+### Other ways
+
+- ADK CLI:
+  ```bash
+  echo '{"identity_type": "AGENT_IDENTITY"}' > .agent_engine_config.json
+  adk deploy ...
+  ```
+- Agents CLI: `agents-cli deploy --agent-identity`
+
+### What gets auto-provisioned
+
+- A SPIFFE ID and matching X.509 certificate (rotated; valid 24 h).
+- `roles/aiplatform.agentDefaultAccess` (basic project logging + model calls).
+- `roles/aiplatform.agentContextEditor` (own sessions, memory, sandboxes).
+- A workload access token bound to the X.509 cert; an authorization DPoP
+  proof; an entry in the agent identity pool.
+
+> If `identity_type` is not configured, the runtime falls back to
+> service-account mode — preserves backward compatibility for existing IaC
+> deployments.
+
+---
+
+## How to inspect / enumerate the identity at runtime
+
+Source: <https://docs.cloud.google.com/gemini-enterprise-agent-platform/scale/runtime/agent-identity>
+
+### Read the effective identity (authoritative)
+
+The `spec.effectiveIdentity` field on the ReasoningEngine GET response is the
+single source of truth. Possible shapes (per the REST reference):
+
+- `service-{project}@gcp-sa-aiplatform-re.googleapis.com` — `SERVICE_AGENT`
+- `{name}@{project}.gserviceaccount.com` — `SERVICE_ACCOUNT`
+- `agents.global.{org}.system.id.goog/resources/aiplatform/projects/{project}/locations/{location}/reasoningEngines/{re}`
+  — `AGENT_IDENTITY`
+
+Example REST response excerpt:
+
+```json
+{
+  "spec": {
+    "effectiveIdentity": "agents.global.org-ORGANIZATION_ID.system.id.goog/resources/aiplatform/projects/PROJECT_ID/locations/LOCATION/reasoningEngines/AGENT_ENGINE_ID"
+  }
+}
+```
+
+### Console
+
+Cloud Console -> Agent Platform Deployments. The "Identity" column lists the
+agent identity for each deployed agent.
+
+### gcloud / curl
+
+REST: `GET projects/PROJECT/locations/LOCATION/reasoningEngines/ID` against
+the v1beta1 endpoint, then read `spec.effectiveIdentity`.
+
+```bash
+curl -s -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+  "https://LOCATION-aiplatform.googleapis.com/v1beta1/projects/PROJECT/locations/LOCATION/reasoningEngines/ID" \
+  | jq '.spec.effectiveIdentity, .spec.identityType, .spec.serviceAccount'
+```
+
+### From inside the agent's container
+
+ADC will already be wired up — confirm with a one-shot tool call:
+
+```python
+from google.auth import default
+creds, project_id = default()
+# creds.service_account_email when SA mode; for AGENT_IDENTITY the credential
+# is system-attested and tied to the metadata server. Use ADC to call any
+# Google API; identity comes from the bound token.
+```
+
+---
+
+## Token format / what shows up in logs
+
+Source: <https://docs.cloud.google.com/access-context-manager/docs/caa-agent-security>
+Source: <https://docs.cloud.google.com/gemini-enterprise-agent-platform/scale/runtime/agent-identity>
+
+Agent Identity uses two artifacts (not a plain bearer JWT):
+
+1. **X.509 certificate** — issued under a Google-managed trust domain. Embeds
+   the agent's SPIFFE ID. Used for mTLS to Agent Gateway.
+2. **Certificate-bound workload access token** — short-lived OAuth-style token
+   *cryptographically bound* to the X.509 cert; carries an encrypted
+   authorization DPoP proof.
+
+Network/auth flow (when Agent Gateway is enabled):
+
+- Agent -> Agent Gateway: mTLS, certificate-bound token.
+- Agent Gateway -> Google Cloud API: DPoP (mTLS terminates at the gateway).
+- CAA verifies the authorization DPoP proof and the resource DPoP proof were
+  signed with the same private key from the agent identity pool.
+
+In Cloud Logging:
+
+- Agent acting on its own authority -> entry shows the agent's SPIFFE
+  identity only.
+- Agent acting on behalf of an end user (via auth manager) -> entry shows
+  *both* the agent identity and the end-user identity.
+
+When grepping logs the SPIFFE identity will look like the
+`agents.global.org-...system.id.goog/resources/aiplatform/...` form (no
+`spiffe://` scheme on most log fields — it's the principal form).
+
+---
+
+## Required roles for the identity to function
+
+Source: <https://docs.cloud.google.com/gemini-enterprise-agent-platform/scale/runtime/agent-identity>
+
+### Granted automatically on create
+
+- `roles/aiplatform.agentDefaultAccess` — basic project-wide logging, model
+  calling.
+- `roles/aiplatform.agentContextEditor` — limit to the agent's own sessions,
+  memories, sandboxes.
+
+### Recommended baseline (grant manually before/after deploy)
+
+| Role | Why |
+|---|---|
+| `roles/aiplatform.expressUser` | Inference, sessions, memory access |
+| `roles/serviceusage.serviceUsageConsumer` | Use project quota + Agent Platform SDK |
+| `roles/browser` | Basic Cloud functionality (resource enumeration) |
+| `roles/logging.logWriter` | Write logs from the agent |
+| `roles/monitoring.metricWriter` | Emit metrics |
+| `roles/cloudapiregistry.viewer` | Look up tools via Cloud API Registry |
+
+### Tool-/MCP-specific (often missed)
+
+- `roles/iamconnectors.user` on the auth-provider resource — required for the
+  agent to use auth manager / OAuth providers. Source:
+  <https://docs.cloud.google.com/iam/docs/troubleshoot-auth-manager>
+- `roles/iap.egressor` — for any IAP-protected egress (e.g.
+  agent-to-MCP-server, agent-to-agent through Agent Gateway). Bound at the
+  gateway/endpoint, not on the agent. Source:
+  <https://docs.cloud.google.com/gemini-enterprise-agent-platform/govern/policies/assign-identity-iam>
+
+### Service-account mode (legacy default)
+
+Default SA: `service-<PROJECT_NUMBER>@gcp-sa-aiplatform-re.iam.gserviceaccount.com`
+with `roles/aiplatform.reasoningEngineServiceAgent`. Custom SAs additionally
+need `roles/storage.objectViewer` (read user GCS) and `roles/aiplatform.user`
+(use Vertex extensions).
+
+---
+
+## Granting roles — exact gcloud commands
+
+Source: <https://docs.cloud.google.com/gemini-enterprise-agent-platform/scale/runtime/agent-identity>
+
+### Single agent
+
+```bash
+gcloud RESOURCE_TYPE add-iam-policy-binding RESOURCE_ID \
+  --member="principal://agents.global.org-ORGANIZATION_ID.system.id.goog/resources/aiplatform/projects/PROJECT_NUMBER/locations/LOCATION/reasoningEngines/AGENT_ENGINE_ID" \
+  --role="ROLE_NAME"
+```
+
+### All agents in a project (with org)
+
+```bash
+gcloud projects add-iam-policy-binding PROJECT_ID \
+  --member="principalSet://agents.global.org-ORGANIZATION_ID.system.id.goog/attribute.platformContainer/aiplatform/projects/PROJECT_NUMBER" \
+  --role=roles/serviceusage.serviceUsageConsumer
+# Repeat for browser, expressUser, cloudapiregistry.viewer, logging.logWriter,
+# monitoring.metricWriter.
+```
+
+### All agents in an orgless project
+
+```bash
+gcloud projects add-iam-policy-binding PROJECT_ID \
+  --member="principalSet://agents.global.project-PROJECT_NUMBER.system.id.goog/attribute.platformContainer/aiplatform/projects/PROJECT_NUMBER" \
+  --role="ROLE_NAME"
+```
+
+### All agents across an org
+
+```bash
+gcloud RESOURCE_TYPE add-iam-policy-binding RESOURCE_ID \
+  --member="principalSet://agents.global.org-ORGANIZATION_ID.system.id.goog/attribute.platform/aiplatform" \
+  --role="ROLE_NAME"
+```
+
+### List the roles attached to a deployed (SA-mode) agent
+
+```bash
+gcloud projects get-iam-policy PROJECT_ID_OR_NUMBER \
+  --flatten="bindings[].members" \
+  --filter="bindings.members:serviceAccount:PRINCIPAL" \
+  --format="value(bindings.role)"
+```
+
+For Agent-Identity mode, filter against the principal string instead:
+
+```bash
+gcloud projects get-iam-policy PROJECT_ID \
+  --flatten="bindings[].members" \
+  --filter="bindings.members:principal://agents.global.org-ORG.system.id.goog/resources/aiplatform/projects/PROJECT_NUMBER/locations/LOCATION/reasoningEngines/AGENT_ID" \
+  --format="value(bindings.role)"
+```
+
+---
+
+## Common debugging scenarios
+
+### "Who is this request from?" — start here
+
+1. `GET` the ReasoningEngine, read `spec.identityType` and
+   `spec.effectiveIdentity`.
+2. If `identityType` is `AGENT_IDENTITY`, the principal in IAM/audit logs
+   will be the SPIFFE-style `agents.global....`. If `SERVICE_ACCOUNT`,
+   expect a `service-...@gcp-sa-aiplatform-re.iam.gserviceaccount.com`
+   (default) or custom SA email.
+3. Search audit logs for that exact string.
+
+### `401 UNAUTHENTICATED` from a Google Cloud API
+
+Source: <https://docs.cloud.google.com/iam/docs/troubleshoot-auth-manager>
+
+```
+{ "error": { "code": 401, "status": "UNAUTHENTICATED",
+  "message": "Request had invalid authentication credentials..." } }
+```
+
+This is usually **Context-Aware Access** rejecting an unbound or shared
+token, not a missing IAM role. Confirm:
+
+- The call originates from the deployed runtime container (not local dev).
+- mTLS / DPoP path is intact (see CAA flow above).
+- If you must work around (NOT recommended in production), set
+  `GOOGLE_API_PREVENT_AGENT_TOKEN_SHARING_FOR_GCP_SERVICES=False` via
+  `env_vars` on `agent_engines.create(...)`. This disables token binding.
+
+### `403 PERMISSION_DENIED` after switching to AGENT_IDENTITY
+
+The Reasoning Engine Service Agent's project-wide grants do **not** transfer
+to the per-agent identity. The agent has only the two default roles. Add
+baseline roles via the principalSet binding above, then per-agent grants for
+sensitive resources.
+
+### IAP / Agent Gateway egress denied
+
+You need an `roles/iap.egressor` binding on the IAP/endpoint with the agent
+principal as `members`. Per the policy assignment doc:
+
+```json
+{
+  "policy": {
+    "bindings": [
+      {
+        "role": "roles/iap.egressor",
+        "members": [
+          "principal://agents.global.org-123456789012.system.id.goog/resources/aiplatform/projects/9876543210/locations/us-central1/reasoningEngines/my-test-agent"
+        ]
+      }
+    ]
+  }
+}
+```
+
+Apply with `gcloud beta iap web set-iam-policy ... --resource-type=AgentRegistry`
+or `--endpoint=ENDPOINT_ID` depending on target.
+
+### Agent can't use an auth provider (auth manager)
+
+Verify `roles/iamconnectors.user` is granted to the agent identity on the
+auth-provider resource.
+
+### OIDC / OAuth issuer reachability
+
+`.well-known/openid-configuration` and JWKS endpoints must be publicly
+reachable; otherwise auth manager cannot validate the third-party provider.
+
+---
+
+## Code: pulling the bound token via ADC inside the agent
+
+Source: <https://docs.cloud.google.com/iam/docs/auth-agent-own-identity>
+
+```python
+from google.auth import default
+from google.cloud import vision
+
+# ADC automatically retrieves the Agent Identity token from the
+# metadata server. No code changes vs. SA mode.
+creds, project_id = default()
+client = vision.ImageAnnotatorClient(credentials=creds, project=project_id)
+```
+
+If you opt out of CAA (token sharing), set on deploy:
+
+```python
+config={
+  "env_vars": {
+    "GOOGLE_API_PREVENT_AGENT_TOKEN_SHARING_FOR_GCP_SERVICES": False,
+  },
+}
+```
+
+---
+
+## Quick reference — useful URLs
+
+- Agent identity overview (govern):
+  <https://docs.cloud.google.com/gemini-enterprise-agent-platform/govern/agent-identity-overview>
+- Agent identity overview (IAM mirror):
+  <https://docs.cloud.google.com/iam/docs/agent-identity-overview>
+- Agent identity in runtime (create / list / grant):
+  <https://docs.cloud.google.com/gemini-enterprise-agent-platform/scale/runtime/agent-identity>
+- Setup identity & permissions:
+  <https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/runtime/setup>
+- Manage agent access (SA mode):
+  <https://docs.cloud.google.com/gemini-enterprise-agent-platform/scale/runtime/manage-agent-access>
+- Principal identifiers (table of all forms):
+  <https://docs.cloud.google.com/iam/docs/principal-identifiers>
+- ReasoningEngineSpec REST reference:
+  <https://docs.cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1beta1/projects.locations.reasoningEngines>
+- Context-Aware Access for agents (mTLS / DPoP):
+  <https://docs.cloud.google.com/access-context-manager/docs/caa-agent-security>
+- Auth manager troubleshooting (401 / connectors role):
+  <https://docs.cloud.google.com/iam/docs/troubleshoot-auth-manager>
+- Auth using agent's own identity (ADC sample):
+  <https://docs.cloud.google.com/iam/docs/auth-agent-own-identity>
+- Assign identity IAM policies (IAP egressor examples):
+  <https://docs.cloud.google.com/gemini-enterprise-agent-platform/govern/policies/assign-identity-iam>

--- a/demos/agent-gateway/.agents/skills/agent-platform-debugger/references/agent-registry.md
+++ b/demos/agent-gateway/.agents/skills/agent-platform-debugger/references/agent-registry.md
@@ -1,0 +1,787 @@
+# Agent Registry — Debugging Reference
+
+Curated reference for diagnosing why agents, MCP servers, and endpoints registered
+in Google Cloud Agent Registry are not accepting traffic through Agent Gateway / IAP.
+
+Scope: Gemini Enterprise Agent Platform — Agent Registry (Preview).
+All commands use `gcloud alpha agent-registry`.
+
+---
+
+## TL;DR for Debugging
+
+Read these first when something is broken.
+
+1. **Agent Registry is default-deny at the gateway.** Agent Gateway uses Identity-Aware Proxy
+   (IAP) to enforce IAM allow/deny policies bound to Agent Registry resources. If a target
+   hostname is not registered as a `Service` (and a matching `roles/iap.egressor` binding
+   does not exist for the calling agent's principal), egress is blocked. Source:
+   `docs.cloud.google.com/iap/docs/agent-overview`.
+
+2. **There are exactly three discoverable resource types**, and they are *projections* of
+   the same writable `Service`:
+   - **Agent** (read-only `Agent`)
+   - **MCP server** (read-only `McpServer`)
+   - **Endpoint** (read-only `Endpoint`)
+   You always create/update/delete via `services`. You list/describe via `agents`,
+   `mcp-servers`, `endpoints`, or `services`. Source:
+   `docs.cloud.google.com/agent-registry/concepts`.
+
+3. **Hostname matching is exact.** A single Google API can be reached at five+ distinct
+   hostnames (base, mTLS, locational, locational-mTLS, REP regional). Each hostname is a
+   *separate* `Service` registration. If your agent calls `bigquery.us-central1.rep.googleapis.com`
+   but you only registered `bigquery.googleapis.com`, the call is denied.
+   See "Hostname Matrix" below.
+
+4. **Manual registration is not supported in `us` or `eu` multi-region locations.** Use a
+   real region (e.g. `us-central1`) or `global`. Source:
+   `docs.cloud.google.com/agent-registry/register-endpoints`.
+
+5. **Two predefined IAM roles control the registry itself**:
+   - `roles/agentregistry.viewer` — discover (list/describe).
+   - `roles/agentregistry.editor` — register/update/delete.
+   These are project-scoped registry permissions, not traffic permissions.
+
+6. **Traffic permissions live on IAP, bound to registry resources.** The role that
+   actually permits an agent to *use* a registered service is `roles/iap.egressor`
+   (`iap.webServiceVersions.egressViaIAP`), bound via `gcloud beta iap web set-iam-policy`
+   with one of: `--resource-type=AgentRegistry` (registry-wide), `--agent=`, `--mcpServer=`,
+   or `--endpoint=` (per-resource). Source:
+   `docs.cloud.google.com/gemini-enterprise-agent-platform/govern/policies/assign-identity-iam`,
+   `docs.cloud.google.com/iam/docs/roles-permissions/iap`.
+
+7. **Identifiers matter:**
+   - `SERVICE_NAME` / `SERVICE_ID` — your chosen short ID for the registry entry.
+   - **Agent identifier (URN)** and **MCP server identifier (URN)** — globally unique,
+     immutable. Used by discovery tools and policy bindings.
+   - **Resource URI** — the actual runtime location (Cloud Run URL, Vertex AI endpoint, GKE
+     deployment). Different from the URN. Embedded in the agent principal for IAM.
+
+8. **Specs have a hard 10 KB cap.** `--mcp-server-spec-content` and `--agent-spec-content`
+   files must be <= 10 KB. Larger specs silently fail validation.
+
+9. **Automatic registration vs manual:** Vertex AI Agent Engine, Google Workspace,
+   Gemini Enterprise, and annotated GKE deployments register *automatically*. Official
+   Google/Google Cloud remote MCP servers register automatically when the API is enabled.
+   Everything else (Cloud Run, on-prem, custom REST agents, third-party MCP) is *manual*.
+
+10. **First debug command** is almost always: list the resource type and confirm the
+    hostname permutation you expect is actually present.
+    `gcloud alpha agent-registry endpoints list --project=$PROJECT_ID --location=$LOCATION`
+
+---
+
+## 1. The Data Model in One Picture
+
+```
+                 WRITE side                          READ side (read-only projections)
+              +--------------+                    +----------+
+              |              |  endpoint-spec --> | Endpoint |
+              |   Service    |  mcp-server-spec ->| McpServer|
+              | (writable)   |  agent-spec -----> |  Agent   |
+              +--------------+                    +----------+
+                ^                                        ^
+         create/update/delete                     get/list/search
+         (services subcommand)                    (endpoints / mcp-servers /
+                                                   agents subcommand)
+```
+
+- The `Service` resource is the only thing you write.
+- Agent Registry **automatically generates** the corresponding `Agent`, `McpServer`, or
+  `Endpoint` projection based on the `*-spec-type` you passed at create time.
+- The `*-spec-type` parameter you use at creation determines which projection appears:
+
+  | Flag                              | Projection becomes |
+  | --------------------------------- | ------------------ |
+  | `--endpoint-spec-type=no-spec`    | `Endpoint`         |
+  | `--mcp-server-spec-type=tool-spec`| `McpServer`        |
+  | `--agent-spec-type=...` (e.g. A2A)| `Agent`            |
+
+Source: `docs.cloud.google.com/agent-registry/overview`,
+`docs.cloud.google.com/agent-registry/concepts`.
+
+### URN formats (memorize these)
+
+- **Manually registered MCP server URN:**
+  `urn:mcp:projects-PROJECT_NUMBER:projects:PROJECT_NUMBER:locations:REGION:agentregistry:SERVICE_ID`
+- **Google Cloud remote MCP server URN:**
+  `urn:mcp:googleapis.com:projects:PROJECT_NUMBER:locations:global:SERVICE_NAME`
+
+If a discovery query returns no results for what you think is a registered server, check
+the URN format vs the location you registered against.
+
+Source: `docs.cloud.google.com/agent-registry/concepts`.
+
+---
+
+## 2. Default-Deny + Hostname Matching
+
+This is the single most common debugging failure mode. Read this whole section.
+
+### Why default-deny
+
+Agent Gateway is the egress proxy for agents. It is built on IAP. IAP only forwards a
+request if there is an IAM allow policy granting `roles/iap.egressor` to the calling
+agent's principal **on a registry resource that matches the request**. If no `Service`
+matches the destination hostname, no policy can match, and the request is denied.
+
+Source: `docs.cloud.google.com/iap/docs/agent-overview`.
+
+### Hostname Matrix — register every form an agent might call
+
+A single Google Cloud API can be addressed via several distinct hostnames. Each one is a
+separate registry entry. Below is the canonical set; if any are missing for an API your
+agent uses, expect denial.
+
+| Variant            | Hostname pattern                                | Example (`bigquery`, `us-central1`)              |
+| ------------------ | ----------------------------------------------- | ------------------------------------------------ |
+| Base / global      | `SERVICE.googleapis.com`                        | `bigquery.googleapis.com`                        |
+| mTLS               | `SERVICE.mtls.googleapis.com`                   | `bigquery.mtls.googleapis.com`                   |
+| Locational         | `LOCATION-SERVICE.googleapis.com`               | `us-central1-bigquery.googleapis.com`            |
+| Locational mTLS    | `LOCATION-SERVICE.mtls.googleapis.com`          | `us-central1-bigquery.mtls.googleapis.com`       |
+| REP (public)       | `SERVICE.LOCATION.rep.googleapis.com`           | `bigquery.us-central1.rep.googleapis.com`        |
+| REP (private/PSC)  | `SERVICE.LOCATION.p.rep.googleapis.com`         | `bigquery.us-central1.p.rep.googleapis.com`      |
+
+- **Locational endpoints** specify the region/multi-region in the URL prefix.
+  Format: `LOCATION-SERVICE.googleapis.com`. Locational endpoints don't support
+  data-residency-compliant connections from on-premises and don't support failure-domain
+  isolation; **REP is replacing them**.
+- **REP (Regional Endpoint)** confines TLS termination and traffic to the specified
+  region. Format: `SERVICE.REGION.rep.googleapis.com`. Private REP via PSC adds `.p.`.
+- The base/global hostname terminates TLS at the nearest edge and provides no regional
+  isolation.
+
+Source: `docs.cloud.google.com/docs/security/compliance/restrict-endpoint-usage`.
+
+### Pattern used in this repo
+
+The terraform module `terraform/modules/agent-registry-endpoints` registers, for each
+Google API, **five `Service` entries per region**, with deterministic IDs:
+
+```
+${id}                          -> https://${id}.googleapis.com
+${id}-mtls                     -> https://${id}.mtls.googleapis.com
+${LOCATION}-${id}              -> https://${LOCATION}-${id}.googleapis.com
+${LOCATION}-${id}-mtls         -> https://${LOCATION}-${id}.mtls.googleapis.com
+${id}-${LOCATION}-rep          -> https://${id}.${LOCATION}.rep.googleapis.com
+```
+
+When debugging "agent can call X but not Y", first check that the hostname Y is using
+matches one of the registered URLs **exactly**. A trailing slash, port, scheme, or extra
+subdomain mismatch will cause denial.
+
+### Quick "is the hostname registered?" check
+
+```bash
+gcloud alpha agent-registry services list \
+  --project=$PROJECT_ID \
+  --location=$LOCATION \
+  --format="table(name.basename(), interfaces.url)" \
+  --filter="interfaces.url:HOSTNAME_FRAGMENT"
+```
+
+Replace `HOSTNAME_FRAGMENT` with e.g. `bigquery.us-central1.rep`.
+
+Source: hostname patterns derived from
+`docs.cloud.google.com/docs/security/compliance/restrict-endpoint-usage`; registration
+flow from `docs.cloud.google.com/agent-registry/register-endpoints`.
+
+---
+
+## 3. Resource Type — Agents
+
+### Concept
+
+> Agents: Autonomous actors that possess specific *skills*. Skills represent an agent's
+> high-level capabilities and are a primary mechanism for discovery.
+> -- `docs.cloud.google.com/agent-registry/concepts`
+
+Two kinds:
+- **A2A-compliant agents** -- implement Agent2Agent. Registry scans their
+  `agent-card.json` to extract skills.
+- **Standard REST agents** -- registered as `NO_SPEC` type when no A2A spec exists.
+
+Automatic registration sources: Vertex AI Agent Engine (via SDK), Google Workspace
+built-ins, Gemini Enterprise built-ins, GKE deployments with the Agent Registry
+functional-type annotation. Everything else is manual.
+
+### List
+
+```bash
+gcloud alpha agent-registry agents list \
+  --project=PROJECT_ID \
+  --location=REGION
+```
+
+Filter:
+
+```bash
+gcloud alpha agent-registry agents list \
+  --project=PROJECT_ID \
+  --location=REGION \
+  --filter="displayName='DISPLAY_NAME'"
+```
+
+### Describe
+
+```bash
+gcloud alpha agent-registry agents describe AGENT_NAME \
+  --project=PROJECT_ID \
+  --location=REGION
+```
+
+Output exposes core details, skills (if A2A), and `Resource URI` -- the runtime location
+of the agent, which is what gets embedded in the agent principal for IAM.
+
+### Update (via `services`, not `agents`)
+
+Display name / description:
+
+```bash
+gcloud alpha agent-registry services update AGENT_NAME \
+  --project=PROJECT_ID \
+  --location=REGION \
+  --display-name="New name" \
+  --description="Updated description"
+```
+
+Endpoint URL:
+
+```bash
+gcloud alpha agent-registry services update AGENT_NAME \
+  --project=PROJECT_ID \
+  --location=REGION \
+  --interfaces=url=ENDPOINT_URL,protocolBinding=PROTOCOL
+```
+
+Valid `protocolBinding`: `HTTP_JSON`, `GRPC`, `JSONRPC`.
+
+Agent spec (max 10 KB):
+
+```bash
+gcloud alpha agent-registry services update AGENT_NAME \
+  --project=PROJECT_ID \
+  --location=REGION \
+  --agent-spec-content=@AGENT_SPEC
+```
+
+### Delete
+
+For automatically registered agents: delete from the source runtime -- registry entry
+follows. For manually registered agents:
+
+```bash
+gcloud alpha agent-registry services delete AGENT_NAME \
+  --project=PROJECT_ID \
+  --location=REGION
+```
+
+> "This action removes the agent from search results and makes it undiscoverable to other
+> tools."
+
+### IAM model for agents
+
+- **Registry permission to manage**: `roles/agentregistry.editor` on the project.
+- **Traffic permission for an agent to talk to *this* agent (agent-to-agent egress)**:
+  bind `roles/iap.egressor` to the *source* agent's principal on the *target* agent
+  resource:
+
+  ```bash
+  gcloud beta iap web set-iam-policy agents-iap-policy.json \
+    --project=PROJECT_ID \
+    --agent=AGENT_ID \
+    --region=REGION
+  ```
+
+  The policy file's `members` is the source agent's principal:
+  - Vertex AI Agent Engine / Gemini Enterprise:
+    `principal://TRUST_DOMAIN/AGENT_UNIQUE_IDENTIFIER`
+    (e.g. `principal://agents.global.org-123456789012.system.id.goog/resources/aiplatform/projects/9876543210/locations/us-central1/reasoningEngines/my-test-agent`)
+  - DIY agents:
+    `principal://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/AGENT_SERVICE_ACCOUNT_IDENTIFIER`
+
+### Common pitfalls
+
+- **Agent registered but not discoverable**: check you're querying the right project +
+  location. Manual registration is rejected in `us`/`eu` multi-regions.
+- **Agent appears in `services list` but not `agents list`**: wrong `*-spec-type` at
+  creation time. The projection only appears for the matching spec type.
+- **Agent "registered" in Vertex AI but missing from registry**: automatic registration
+  only happens for Agent Engine SDK-deployed agents. A custom Cloud Run agent does **not**
+  auto-register.
+- **A2A agent missing skills**: registry couldn't reach the agent's `agent-card.json`
+  endpoint. Check the agent's published Agent Card URL is publicly reachable from
+  Google's registration crawler.
+
+Sources: `docs.cloud.google.com/agent-registry/manage-agents`,
+`docs.cloud.google.com/agent-registry/register-agents`,
+`docs.cloud.google.com/gemini-enterprise-agent-platform/govern/policies/assign-identity-iam`.
+
+---
+
+## 4. Resource Type — MCP Servers
+
+### Concept
+
+> MCP servers: Providers of standardized data resources and *tools*. Tools are
+> deterministic functions exposed by an MCP server that agents can invoke to perform
+> specific actions.
+> -- `docs.cloud.google.com/agent-registry/concepts`
+
+Official Google and Google Cloud remote MCP servers are auto-registered on API enable.
+External / custom MCP servers (e.g. Cloud Run-hosted FastMCP) need manual registration
+with a tool spec.
+
+### Register
+
+```bash
+gcloud alpha agent-registry services create SERVER_NAME \
+  --project=PROJECT_ID \
+  --location=REGION \
+  --display-name="DISPLAY_NAME" \
+  --mcp-server-spec-type=tool-spec \
+  --mcp-server-spec-content=@toolspec.json \
+  --interfaces=url=SERVER_URL,protocolBinding=PROTOCOL
+```
+
+- `PROTOCOL` for MCP is typically `JSONRPC`.
+- `toolspec.json` must be <= **10 KB**, conform to the MCP tool schema (name, description,
+  optional annotations).
+
+### List
+
+```bash
+gcloud alpha agent-registry mcp-servers list \
+  --project=PROJECT_ID \
+  --location=REGION
+```
+
+Useful filters:
+- `displayName='NAME'`
+- `mcpServerId='urn:mcp:SERVER_URN'` (filter by URN -- see URN format above)
+
+### Describe
+
+```bash
+gcloud alpha agent-registry mcp-servers describe SERVER_NAME \
+  --project=PROJECT_ID \
+  --location=REGION
+```
+
+The describe output includes the tool catalog and an ADK code snippet to wire the server
+into an agent.
+
+### Update tool spec
+
+Tool spec changes are not auto-detected -- re-upload when the server adds/changes tools:
+
+```bash
+gcloud alpha agent-registry services update SERVER_NAME \
+  --project=PROJECT_ID \
+  --location=REGION \
+  --mcp-server-spec-content=@TOOL_SPEC
+```
+
+### Delete
+
+```bash
+gcloud alpha agent-registry services delete SERVER_NAME \
+  --project=PROJECT_ID \
+  --location=REGION
+```
+
+### IAM model for MCP servers
+
+- **Discover MCP servers/tools**: `roles/agentregistry.viewer`.
+- **Update tool definitions / register**: `roles/agentregistry.editor`.
+- **Use the Agent Registry remote MCP server itself**: `roles/mcp.toolUser` for
+  `mcp.tools.call`, plus the viewer role for discovery.
+- **Agent-to-MCP egress** (the actual traffic permission): bind `roles/iap.egressor`
+  to the source agent's principal on the MCP server resource:
+
+  ```bash
+  gcloud beta iap web set-iam-policy agents-iap-policy.json \
+    --project=PROJECT_ID \
+    --mcpServer=MCP_SERVER_ID \
+    --region=REGION
+  ```
+
+  CEL conditions can scope the binding to specific tools and to read-only or
+  non-destructive calls. Documented condition attributes include:
+  - `iap.googleapis.com/mcp.toolName`
+  - `iap.googleapis.com/mcp.tool.isReadOnly`
+  - `iap.googleapis.com/request.auth.type` (e.g. `'MCP'`)
+
+  Example condition expression:
+  ```
+  api.getAttribute('iap.googleapis.com/mcp.toolName', '') == 'GitHubTool' &&
+  api.getAttribute('iap.googleapis.com/mcp.tool.isReadOnly', false) == true &&
+  api.getAttribute('iap.googleapis.com/request.auth.type', '') == 'MCP'
+  ```
+
+### Common pitfalls
+
+- **Agent calls a tool, gets denied**: the IAP policy condition may restrict to
+  `isReadOnly == true` while the tool is destructive, or `mcp.toolName` doesn't match.
+- **Tool added to MCP server but agents can't see it**: tool spec wasn't re-uploaded.
+  `services update --mcp-server-spec-content` is mandatory after every server-side change.
+- **Spec upload silently rejected**: file > 10 KB.
+- **Manual registration error in `us` / `eu`**: not supported. Use a region or `global`.
+- **MCP server registered but appears under `services list` only, not `mcp-servers
+  list`**: wrong spec type -- must be `--mcp-server-spec-type=tool-spec`.
+
+Sources: `docs.cloud.google.com/agent-registry/register-mcp-servers`,
+`docs.cloud.google.com/agent-registry/manage-mcp-tools`,
+`docs.cloud.google.com/agent-registry/use-agentregistry-mcp`,
+`docs.cloud.google.com/gemini-enterprise-agent-platform/govern/policies/assign-identity-iam`.
+
+---
+
+## 5. Resource Type — Endpoints
+
+### Concept
+
+> Endpoints: Target URLs, typically REST APIs, accessed by an agent. By abstracting these
+> destinations into manageable resources, Agent Registry lets you centrally govern which
+> external services your agents can access.
+> -- `docs.cloud.google.com/agent-registry/concepts`
+
+Endpoints are how you authorize an agent to reach **anything that isn't an agent or an
+MCP server**: Google APIs (BigQuery, Vertex AI, etc.), third-party REST APIs, internal
+HTTP services. Always manually registered.
+
+### Register
+
+```bash
+gcloud alpha agent-registry services create SERVICE_NAME \
+  --project=PROJECT_ID \
+  --location=REGION \
+  --display-name="DISPLAY_NAME" \
+  --endpoint-spec-type=no-spec \
+  --interfaces=url=ENDPOINT_URL,protocolBinding=PROTOCOL
+```
+
+- `--endpoint-spec-type=no-spec` is mandatory -- this is what causes the read-only
+  `Endpoint` projection to appear.
+- After creation, Agent Registry auto-generates the read-only `Endpoint` resource that
+  agents discover.
+
+> **Hostname registration is exact-match.** You must register *every* hostname variant
+> the agent might dial. See "Hostname Matrix" in section 2. The fix for "endpoint
+> registered but traffic denied" is almost always: register the missing variant.
+
+### List
+
+```bash
+gcloud alpha agent-registry endpoints list \
+  --project=PROJECT_ID \
+  --location=REGION
+```
+
+Filter:
+
+```bash
+gcloud alpha agent-registry endpoints list \
+  --project=PROJECT_ID \
+  --location=REGION \
+  --filter="displayName='NAME'"
+```
+
+For URL-substring search, list `services` instead and filter on `interfaces.url`:
+
+```bash
+gcloud alpha agent-registry services list \
+  --project=PROJECT_ID \
+  --location=REGION \
+  --format="table(name.basename(), interfaces.url, interfaces.protocolBinding)" \
+  --filter="interfaces.url:HOSTNAME_FRAGMENT"
+```
+
+### Describe
+
+```bash
+gcloud alpha agent-registry endpoints describe ENDPOINT_NAME \
+  --project=PROJECT_ID \
+  --location=REGION
+```
+
+### Update
+
+```bash
+gcloud alpha agent-registry services update SERVICE_NAME \
+  --project=PROJECT_ID \
+  --location=REGION \
+  --interfaces=url=ENDPOINT_URL,protocolBinding=PROTOCOL
+```
+
+### Delete
+
+```bash
+gcloud alpha agent-registry services delete SERVICE_NAME \
+  --project=PROJECT_ID \
+  --location=REGION
+```
+
+> "This action immediately removes the endpoint from discovery search results."
+> Console UI requires typing `DELETE` to confirm.
+
+### IAM model for endpoints
+
+- **Discover endpoints**: `roles/agentregistry.viewer`.
+- **Register / update / delete**: `roles/agentregistry.editor`.
+- **Agent-to-endpoint traffic**: bind `roles/iap.egressor` to the source agent's
+  principal on the endpoint resource:
+
+  ```bash
+  gcloud beta iap web set-iam-policy agents-iap-policy.json \
+    --project=PROJECT_ID \
+    --endpoint=ENDPOINT_ID \
+    --region=REGION
+  ```
+
+  Per-endpoint policy bindings do not require a CEL condition; you can omit `condition`
+  to grant unconditional egress to that one endpoint, or add a CEL condition for
+  attribute-based scoping (e.g. by `Name`, `ReadOnly`, `Destructive`, `Idempotent`,
+  `OpenWorld` properties).
+
+### Note on `roles/iap.tunnelResourceAccessor`
+
+Some IAP-protected resources use `roles/iap.tunnelResourceAccessor`
+(`iap.tunnelDestGroups.accessViaIAP`, `iap.tunnelInstances.accessViaIAP`) -- that role
+governs **classic IAP TCP tunnels** to GCE instances and dest groups. **Agent Gateway
+egress to Agent Registry resources does NOT use this role**; it uses
+`roles/iap.egressor` (`iap.webServiceVersions.egressViaIAP`). If you see a tutorial
+suggesting `tunnelResourceAccessor` for agent egress, it's the wrong role -- confirm
+against `docs.cloud.google.com/iam/docs/roles-permissions/iap`.
+
+### Common pitfalls
+
+- **`Test connection` fails in console for a private URL**: expected. The console
+  connection test only validates *public* URLs; it does not support private endpoints
+  (Vertex AI, internal HTTPS, etc.).
+- **Agent gets denied on a Google API call**: the API has a hostname variant you didn't
+  register (commonly the REP regional form `${id}.${LOCATION}.rep.googleapis.com`).
+- **Endpoint registered in `global` but agent calls a regional URL**: registry location
+  doesn't have to match the destination URL location, but the IAM binding's `--region` must
+  match where the resource is registered. Check that `--region=` on
+  `gcloud beta iap web set-iam-policy` equals the location used at creation.
+- **Endpoint not appearing in `endpoints list`**: created with the wrong spec type. Must
+  use `--endpoint-spec-type=no-spec`.
+
+Sources: `docs.cloud.google.com/agent-registry/register-endpoints`,
+`docs.cloud.google.com/agent-registry/manage-endpoints`,
+`docs.cloud.google.com/iam/docs/roles-permissions/iap`,
+`docs.cloud.google.com/gemini-enterprise-agent-platform/govern/policies/assign-identity-iam`.
+
+---
+
+## 6. IAM Scope: Registry-Wide vs Per-Resource
+
+There are two layers. Don't conflate them.
+
+### Layer A — Agent Registry permissions (manage the catalog)
+
+Project-scoped, granted via standard IAM:
+
+| Role                            | Use                                              |
+| ------------------------------- | ------------------------------------------------ |
+| `roles/agentregistry.viewer`    | List / describe / search agents, MCP, endpoints  |
+| `roles/agentregistry.editor`    | Create / update / delete `Service` resources     |
+| `roles/mcp.toolUser`            | Call tools via the Agent Registry remote MCP server (`mcp.tools.call`) |
+
+These let humans and CI register and inspect entries. They do **not** grant runtime
+traffic.
+
+### Layer B — IAP egress permissions (let an agent actually send traffic)
+
+Bound on Agent Registry resources via `gcloud beta iap web set-iam-policy`. The role is
+always `roles/iap.egressor`. The scope of the binding determines which target resources
+the source agent can reach:
+
+| Scope                  | gcloud target flag           | Grants egress to                              |
+| ---------------------- | ---------------------------- | --------------------------------------------- |
+| Registry-wide          | `--resource-type=AgentRegistry` | All agents + MCP servers + endpoints in the project's registry |
+| Single agent           | `--agent=AGENT_ID`           | One target agent                              |
+| Single MCP server      | `--mcpServer=MCP_SERVER_ID`  | One target MCP server                         |
+| Single endpoint        | `--endpoint=ENDPOINT_ID`     | One target endpoint                           |
+
+All four take `--project=PROJECT_ID` and `--region=REGION` (or `--folder` /
+`--organization` for higher-scoped binding).
+
+The policy JSON is uniform:
+
+```json
+{
+  "policy": {
+    "bindings": [
+      {
+        "role": "roles/iap.egressor",
+        "members": ["AGENT_PRINCIPAL"],
+        "condition": { "title": "...", "expression": "..." }
+      }
+    ]
+  }
+}
+```
+
+Source: `docs.cloud.google.com/gemini-enterprise-agent-platform/govern/policies/assign-identity-iam`.
+
+### Agent principal formats (the `members` value)
+
+- **Vertex AI Agent Engine / Gemini Enterprise**:
+  `principal://TRUST_DOMAIN/AGENT_UNIQUE_IDENTIFIER`
+  Example:
+  `principal://agents.global.org-123456789012.system.id.goog/resources/aiplatform/projects/9876543210/locations/us-central1/reasoningEngines/my-test-agent`
+
+- **DIY agents (Cloud Run, GKE, on-prem)**:
+  `principal://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/AGENT_SERVICE_ACCOUNT_IDENTIFIER`
+  Example:
+  `principal://iam.googleapis.com/projects/1234567890/locations/global/workloadIdentityPools/my-agent-identity/subject/ns/default/sa/my-agent`
+
+- **Agent hierarchy (whole platform container)**:
+  `principalSet://agents.global.org-ORGANIZATION_ID.system.id.goog/attribute.platformContainer/aiplatform/projects/1234`
+
+When debugging "wrong principal" errors: the principal is built from the agent's
+**resource URI**, not its display name and not its URN. View the resource URI via
+`gcloud alpha agent-registry agents describe`.
+
+### Full IAP role reference (relevant subset)
+
+| Role                                | Permission grants the role provides          | When to use                            |
+| ----------------------------------- | -------------------------------------------- | -------------------------------------- |
+| `roles/iap.egressor` (Beta)         | `iap.webServiceVersions.egressViaIAP`        | **Agent egress through Agent Gateway** |
+| `roles/iap.httpsResourceAccessor`   | `iap.webServiceVersions.accessViaIAP`        | Human/service ingress to an IAP-protected web app |
+| `roles/iap.tunnelResourceAccessor`  | `iap.tunnelDestGroups.accessViaIAP`, `iap.tunnelInstances.accessViaIAP` | Classic IAP TCP tunnels to GCE -- **not** for agent gateway |
+| `roles/iap.admin`                   | Full IAP admin (`iap.tunnel.*`, all getIam/setIam) | Manage IAP policies                  |
+| `roles/iap.viewer`                  | Read IAP settings                            | Audit                                  |
+
+Source: `docs.cloud.google.com/iam/docs/roles-permissions/iap`.
+
+---
+
+## 7. Common Registration Errors and Where to Look
+
+| Symptom                                                              | Likely cause                                                                 | Where to check                                                                 |
+| -------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `services create` fails: "manual registration not supported"         | Used `--location=us` or `--location=eu` (multi-regions)                      | Switch to a region (e.g. `us-central1`) or `global`                            |
+| `services create` succeeds but resource missing from `endpoints list`| Wrong `*-spec-type`. `--endpoint-spec-type=no-spec` produces an `Endpoint`.  | Re-create with the correct spec-type, or check `services list`                 |
+| `services update --mcp-server-spec-content` rejects file             | Spec > 10 KB                                                                 | Trim the tool spec                                                             |
+| Agent calls API X, IAP returns 403                                   | Hostname variant not registered (commonly REP `*.LOCATION.rep.googleapis.com`) | `services list --filter="interfaces.url:FRAGMENT"`                             |
+| Agent calls API X, IAP returns 403 even though hostname is registered| Missing `roles/iap.egressor` binding for the source agent's principal        | `gcloud beta iap web get-iam-policy --project= --region= --endpoint=...` (or `--mcpServer=`, `--agent=`, `--resource-type=AgentRegistry`) |
+| MCP tool call succeeds for one tool, denied for another              | IAP policy condition restricts `mcp.toolName` or `mcp.tool.isReadOnly`       | Inspect the IAP policy on the MCP server resource                              |
+| Auto-registered Vertex AI agent missing from registry                | Agent deployed via custom code, not Agent Engine SDK                         | Re-deploy via Agent Engine, or register manually as a `Service`                |
+| A2A agent has no skills in registry                                  | `agent-card.json` unreachable from Google's crawler                          | Curl the Agent Card URL from a public network; verify content type and schema  |
+| Agent principal mismatch in IAP policy                               | Principal built from wrong resource URI / project number / SA identifier     | `gcloud alpha agent-registry agents describe` -> use Resource URI to construct |
+| `roles/iap.tunnelResourceAccessor` granted, still denied             | Wrong role -- agent egress requires `roles/iap.egressor`                     | Replace the binding                                                            |
+| Endpoint console "Test connection" fails on private URL              | Connection test only works for public URLs (by design)                       | Test via the agent itself or `curl` from a peered network                      |
+| `agents-iap-policy.json` set, still denied                           | Wrong `--region` flag on `set-iam-policy` -- must match resource location    | Re-issue with the correct `--region`                                           |
+| Cannot find URN for binding                                          | Use `mcp-servers describe` / `agents describe` and read the `name` field; format per section 1 | See URN formats above                                                          |
+
+---
+
+## 8. Discovery via the Agent Registry MCP Server
+
+The registry itself is exposed as a remote MCP server at
+`agentregistry.googleapis.com`. Useful when debugging from inside an agent or via
+`mcp inspector`. Tools include:
+
+Discovery:
+- `search_agents`, `search_mcp_servers` -- keyword/prefix search
+- `get_agent`, `get_mcp_server`, `get_endpoint` -- by resource name
+- `get_service` -- read the underlying writable spec
+- `list_agents`, `list_mcp_servers`, `list_endpoints`, `list_services`
+- `list_bindings`, `get_binding`, `fetch_available_bindings`
+- `get_operation`
+
+Administrative:
+- `create_service`, `update_service`, `delete_service`
+- `create_binding`, `update_binding`, `delete_binding`
+
+`tools/list` over MCP does not require auth:
+
+```http
+POST /mcp HTTP/1.1
+Host: agentregistry.googleapis.com
+Content-Type: application/json
+
+{ "jsonrpc": "2.0", "method": "tools/list" }
+```
+
+Source: `docs.cloud.google.com/agent-registry/use-agentregistry-mcp`.
+
+---
+
+## 9. Quick Reference — Every gcloud Subcommand
+
+```bash
+# READ
+gcloud alpha agent-registry agents      list   --project=P --location=L
+gcloud alpha agent-registry agents      describe NAME --project=P --location=L
+gcloud alpha agent-registry mcp-servers list   --project=P --location=L
+gcloud alpha agent-registry mcp-servers describe NAME --project=P --location=L
+gcloud alpha agent-registry endpoints   list   --project=P --location=L
+gcloud alpha agent-registry endpoints   describe NAME --project=P --location=L
+gcloud alpha agent-registry services    list   --project=P --location=L
+gcloud alpha agent-registry services    describe NAME --project=P --location=L
+
+# WRITE  (always 'services'; the projection follows from --*-spec-type)
+gcloud alpha agent-registry services create NAME \
+    --project=P --location=L --display-name="..." \
+    --endpoint-spec-type=no-spec \
+    --interfaces=url=URL,protocolBinding=HTTP_JSON|GRPC|JSONRPC
+
+gcloud alpha agent-registry services create NAME \
+    --project=P --location=L --display-name="..." \
+    --mcp-server-spec-type=tool-spec \
+    --mcp-server-spec-content=@toolspec.json \
+    --interfaces=url=URL,protocolBinding=JSONRPC
+
+gcloud alpha agent-registry services create NAME \
+    --project=P --location=L --display-name="..." \
+    --agent-spec-content=@agent-card.json \
+    --interfaces=url=URL,protocolBinding=HTTP_JSON
+
+gcloud alpha agent-registry services update NAME \
+    --project=P --location=L \
+    [ --display-name="..." | --description="..." \
+      | --interfaces=url=URL,protocolBinding=... \
+      | --mcp-server-spec-content=@spec.json \
+      | --agent-spec-content=@card.json ]
+
+gcloud alpha agent-registry services delete NAME --project=P --location=L
+
+# IAP egress policy bindings (separate API, separate gcloud surface)
+gcloud beta iap web set-iam-policy POLICY.json \
+    --project=P --region=L \
+    [ --resource-type=AgentRegistry
+    | --agent=AGENT_ID
+    | --mcpServer=MCP_SERVER_ID
+    | --endpoint=ENDPOINT_ID ]
+
+gcloud beta iap web get-iam-policy \
+    --project=P --region=L \
+    [ same target flags ]
+```
+
+Spec size cap: **10 KB** for `--mcp-server-spec-content` and `--agent-spec-content`.
+
+Manual registration locations: any region or `global`. **Not** `us` or `eu`.
+
+---
+
+## Source Index
+
+- Agent Registry overview: https://docs.cloud.google.com/agent-registry/overview
+- Agent Registry concepts: https://docs.cloud.google.com/agent-registry/concepts
+- Register agents (manual): https://docs.cloud.google.com/agent-registry/register-agents
+- Manage agents: https://docs.cloud.google.com/agent-registry/manage-agents
+- Register MCP servers: https://docs.cloud.google.com/agent-registry/register-mcp-servers
+- Manage MCP servers/tools: https://docs.cloud.google.com/agent-registry/manage-mcp-tools
+- Register endpoints: https://docs.cloud.google.com/agent-registry/register-endpoints
+- Manage endpoints: https://docs.cloud.google.com/agent-registry/manage-endpoints
+- Agent Registry MCP server: https://docs.cloud.google.com/agent-registry/use-agentregistry-mcp
+- Govern (Gemini Enterprise Agent Platform): https://docs.cloud.google.com/gemini-enterprise-agent-platform/govern/agent-registry
+- IAP for agents: https://docs.cloud.google.com/iap/docs/agent-overview
+- IAP IAM roles: https://docs.cloud.google.com/iam/docs/roles-permissions/iap
+- Assign identity / IAP egress policies: https://docs.cloud.google.com/gemini-enterprise-agent-platform/govern/policies/assign-identity-iam
+- Regional service endpoint hostname formats: https://docs.cloud.google.com/docs/security/compliance/restrict-endpoint-usage

--- a/demos/agent-gateway/.agents/skills/agent-platform-debugger/references/field-manual.md
+++ b/demos/agent-gateway/.agents/skills/agent-platform-debugger/references/field-manual.md
@@ -1,0 +1,269 @@
+# Field manual: Agent Gateway / Registry / Identity / IAP
+
+Practical debugging knowledge for the GCP Gemini Enterprise Agent Platform, distilled from real incident triage. Read this *before* diving into the official docs — it covers the gotchas that the docs don't surface.
+
+## The mental model
+
+The Agent Platform runs as **default-deny egress**. An agent (typically a Vertex AI ReasoningEngine) cannot talk to *anything* outside itself unless every layer permits it:
+
+1. **Agent Registry** — the destination must be registered as an Endpoint, MCP Server, or Agent.
+2. **Agent Gateway** — intercepts the request (it sits in front of the agent's egress). Note: an `authz_policy` must explicitly target the gateway resource, otherwise the authz extension won't actually run.
+3. **Service-extension (delegated authz)** — the gateway calls IAP to make an allow/deny decision.
+4. **IAP / IAM** — the agent's identity must have the **IAP egressor role** (`roles/iap.egressor`, display name "IAP-secured Egressor") on the registered resource, or be in a principal set that does.
+5. **Principal Access Boundary (PAB)** — even with the IAM binding correct, a PAB policy on the principal set can restrict which resources it can reach. **PAB takes precedence over IAM Allow** — a correct egressor binding does nothing if a PAB scopes the principal away from the target.
+
+**Implementation note.** Agent Gateway is built on a Google-managed Secure Web Proxy instance that provides the egress-proxy capabilities. Customers don't configure the proxy directly — its rules are derived from registry entries and authz policies. Denials *can* originate at this proxy layer before IAP runs (no IAP audit entry exists for those calls); those show up in load-balancer logs (see Step 3b).
+
+### Don't confuse `roles/iap.egressor` with other IAP roles
+
+The display name "IAP-secured Egressor" maps to **`roles/iap.egressor`** — that's the role for Agent Gateway egress. Two other IAP roles exist that are easy to mistake for it but are unrelated:
+
+| Role ID | Purpose | Use for Agent Gateway? |
+|---|---|---|
+| `roles/iap.egressor` | Agent egress through Agent Gateway | **Yes — this one** |
+| `roles/iap.tunnelResourceAccessor` | TCP/SSH tunneling through IAP to a VM | No |
+| `roles/iap.httpsResourceAccessor` | Access to IAP-protected web apps (ingress) | No |
+| `roles/iap.tunnelDestGroupUser` | Member of an IAP tunnel destination group | No |
+
+Don't substitute. The IAP authz check explicitly looks for `iap.webServiceVersions.egressViaIAP`, which only `roles/iap.egressor` grants for the Agent Gateway path.
+
+If any layer says no, the agent gets back a 403:
+
+```
+{'code': 403, 'message': "403 Forbidden. {'message': 'Egress request is not authorized.', 'status': 'Forbidden'}"}
+```
+
+## The single biggest gotcha: hostname permutations
+
+A Google API like `aiplatform.googleapis.com` is reachable through *many* hostnames. The agent might call any of them depending on the SDK version, regional client config, or whether mTLS is in play:
+
+| Form | Example |
+|---|---|
+| Base | `aiplatform.googleapis.com` |
+| Base + mTLS | `aiplatform.mtls.googleapis.com` |
+| Locational | `us-central1-aiplatform.googleapis.com` |
+| Locational + mTLS | `us-central1-aiplatform.mtls.googleapis.com` |
+| Regional REP (public) | `aiplatform.us-central1.rep.googleapis.com` |
+| Regional REP (private/PSC) | `aiplatform.us-central1.p.rep.googleapis.com` |
+
+**The gateway matches hostnames exactly.** If you registered only `aiplatform.googleapis.com` but the SDK actually called `us-central1-aiplatform.googleapis.com`, the request gets denied — even though "the API is registered." When investigating a 403, *always* establish what hostname the agent actually called, then verify that *exact* hostname is in the registry.
+
+A registration script typically looks like this (note all five permutations):
+
+```bash
+reg_svc "${id}"                   "${name}"                "https://${id}.googleapis.com"
+reg_svc "${id}-mtls"              "${name} mTLS"           "https://${id}.mtls.googleapis.com"
+reg_svc "${LOCATION}-${id}"       "${name} Locational"     "https://${LOCATION}-${id}.googleapis.com"
+reg_svc "${LOCATION}-${id}-mtls"  "${name} Locational mTLS" "https://${LOCATION}-${id}.mtls.googleapis.com"
+reg_svc "${id}-${LOCATION}-rep"   "${name} Regional (REP)" "https://${id}.${LOCATION}.rep.googleapis.com"
+```
+
+## Services that almost always need to be registered
+
+For a typical agent doing inference + observability, these service IDs need endpoints registered (each with all hostname permutations above):
+
+- `aiplatform`
+- `cloudresourcemanager`
+- `discoveryengine`
+- `logging`
+- `monitoring`
+- `oauth2`
+- `telemetry`
+- `trace`
+- `agentregistry`
+- `iap`
+- `modelarmor`
+- `iamcredentials`
+
+Missing any of these is the most common "agent works in dev, fails in prod" cause.
+
+## Diagnostic playbook
+
+### Step 1 — Confirm the symptom in agent logs
+
+Check the ReasoningEngine logs for the 403:
+
+```
+resource.type="aiplatform.googleapis.com/ReasoningEngine"
+resource.labels.location=$LOCATION
+resource.labels.reasoning_engine_id=$AGENT_ID
+textPayload:"403"
+```
+
+The error payload tells you *that* it failed. To learn *why*, you have to correlate to the gateway and IAP.
+
+### Step 2 — Find the failing hostname in gateway logs
+
+```
+resource.type="networkservices.googleapis.com/Gateway"
+resource.labels.location="REGION"
+resource.labels.gateway_name="AGENT_GATEWAY_NAME"
+```
+
+The gateway log entry shows the actual hostname the request was for. Write it down — you'll need it in step 4.
+
+### Step 3 — Check IAP allow/deny decision
+
+Narrow the noise by scoping to the egress permission and excluding base-protocol MCP method noise:
+
+```
+protoPayload.serviceName="iap.googleapis.com"
+protoPayload.authorizationInfo.permission="iap.webServiceVersions.egressViaIAP"
+-protoPayload.metadata.mcp_attributes.base_protocol_method="true"
+```
+
+What to read out of each entry:
+
+- **`protoPayload.authorizationInfo[].granted`** — `true` or `false`. The bottom-line allow/deny.
+- **`protoPayload.authenticationInfo.principalSubject`** — the SPIFFE / `principal://...` URI of the caller. This is the identity IAP saw; compare it to the binding's principal verbatim.
+- **`protoPayload.authorizationInfo[].resource`** — the registered resource the call resolved to.
+- **`labels."iap.googleapis.com/audited_resource_name"`** — if this is `unregisteredResource`, the destination hostname isn't in the registry at all (or doesn't match exactly). That's a hostname-permutation miss, full stop — go to Step 4.
+- **The enforcement mode** — is IAP in dry-run? If you see metadata like this, IAP is observing but not enforcing:
+
+  ```yaml
+  service: iap.googleapis.com
+  failOpen: true
+  timeout: 1s
+  metadata:
+    iamEnforcementMode: "DRY_RUN"
+  ```
+
+  In `DRY_RUN` mode, denials are logged but the request proceeds. So if your agent is failing with a real 403 *and* IAP is in dry-run, the denial is coming from somewhere else — most often the gateway's underlying egress proxy (see Step 3b) or the destination service itself.
+
+### Step 3b — If there's no IAP audit entry for the failing call, pull the gateway proxy load-balancer log
+
+The gateway's underlying egress proxy can deny a request before IAP runs — when that happens, no IAP audit-log entry exists for the call. The denial is in the proxy's load-balancer log instead. The `SECURE_WEB_GATEWAY` label here refers to the proxy implementation under the hood (Google-managed; not customer-configured):
+
+```
+jsonPayload.@type="type.googleapis.com/google.cloud.loadbalancing.type.LoadBalancerLogEntry"
+-httpRequest.requestMethod="CONNECT"
+resource.labels.gateway_type="SECURE_WEB_GATEWAY"
+```
+
+Key fields: `httpRequest.status` (look for 403), `jsonPayload.authzPolicyInfo.policies.result` (overall AuthZ result), `httpRequest.requestUrl` (exact destination).
+
+### Step 4 — Verify the hostname is registered (in the form the agent used)
+
+List registry entries — pick the right resource type for the destination:
+
+```bash
+gcloud alpha agent-registry endpoints list      --project=$PROJECT_ID --location=$LOCATION
+gcloud alpha agent-registry mcp-servers list    --project=$PROJECT_ID --location=$LOCATION
+gcloud alpha agent-registry agents list         --project=$PROJECT_ID --location=$LOCATION
+```
+
+Grep the output for the exact hostname from step 2. If it's missing, that's the root cause — the agent is calling a permutation that was never registered.
+
+### Step 5 — Verify IAM bindings on the registered resource
+
+The agent's identity (or a principal set it belongs to) needs the IAP egressor role on the destination. Bindings can live at the **registry level** (covers everything) or on a **specific resource** (fine-grained).
+
+#### Registry-level IAM policy
+
+```bash
+curl -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
+  -d '{}' \
+  -X POST "https://iap.googleapis.com/v1/projects/${PROJECT_NUMBER}/locations/${LOCATION}/iap_web/agentRegistry:getIamPolicy" \
+  -H "Content-Type: application/json"
+```
+
+#### Per-endpoint IAM policy
+
+```bash
+curl -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
+  -d '{}' \
+  -X POST "https://iap.googleapis.com/v1/projects/${PROJECT_NUMBER}/locations/${LOCATION}/iap_web/agentRegistry/endpoints/${ENDPOINT_ID}:getIamPolicy" \
+  -H "Content-Type: application/json"
+```
+
+#### Same call, but for global registry (some resources live here, not regionally):
+
+```bash
+curl -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
+  -d '{"options": {"requestedPolicyVersion": 3}}' \
+  -X POST "https://iap.googleapis.com/v1/projects/${PROJECT_NUMBER}/locations/global/iap_web/agentRegistry:getIamPolicy" \
+  -H "Content-Type: application/json"
+```
+
+When reading the returned policy, look for a binding that matches *one of*:
+
+- The agent's service account (e.g., `serviceAccount:my-agent@…iam.gserviceaccount.com`)
+- A principal set the agent belongs to
+
+…with role `roles/iap.tunnelResourceAccessor` (the "IAP egressor" role).
+
+### Step 6 — Inspect the gateway / authz extension wiring
+
+#### List authz extensions (the service-extension callouts)
+
+```bash
+gcloud beta service-extensions authz-extensions list \
+  --location=$LOCATION --project=$PROJECT_ID
+
+gcloud beta service-extensions authz-extensions describe RESOURCE_NAME \
+  --location=$LOCATION --project=$PROJECT_ID
+```
+
+Confirm the extension exists, is attached to the right gateway, and points at IAP.
+
+#### List authz policies, agent gateways, and authz extensions via raw API
+
+```bash
+# authzPolicies
+curl -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
+  "https://networksecurity.googleapis.com/v1alpha1/projects/${PROJECT_ID}/locations/${LOCATION}/authzPolicies"
+
+# agentGateways
+curl -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
+  "https://networkservices.googleapis.com/v1alpha1/projects/${PROJECT_ID}/locations/${LOCATION}/agentGateways"
+
+# authzExtensions
+curl -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
+  "https://serviceextensions.googleapis.com/v1alpha1/projects/${PROJECT_ID}/locations/${LOCATION}/authzExtensions"
+```
+
+### Step 7 — Verify the agent identity has the baseline roles
+
+The agent identity itself needs enough permissions to function on the source side. Without these, you can get errors that look like authz failures but are actually about the agent not being able to read its own runtime config:
+
+- `roles/aiplatform.user` (Vertex AI User) — to run the ReasoningEngine
+- Agent Registry viewer role — to know what's registered
+- `roles/logging.logWriter`, `roles/monitoring.metricWriter`, telemetry roles — observability
+- `roles/browser` — needed for `resourcemanager.projects.get` during SDK init. Without it, the ReasoningEngine fails startup with `Failed to convert project number to project ID` (see known-issues §1).
+
+### Step 7b — Check Principal Access Boundary (PAB) policies
+
+Even with all the IAM bindings correct, a PAB policy can override IAM Allow and restrict the resources the principal set can reach. Symptom: the binding looks right, the resource is registered, the role is correct, and it still 403s.
+
+```bash
+# List org-wide PAB policies
+gcloud iam principal-access-boundary-policies list \
+  --organization="${ORGANIZATION_ID}" --location=global
+
+# Find what's bound to the agent's principal set
+gcloud iam policy-bindings search-target-policy-bindings \
+  --project="${PROJECT_ID}" --target="${PRINCIPAL_SET}"
+```
+
+If a PAB binding exists for the principal set, inspect its `details.rules[].resources[]` — the destination must be in scope, otherwise the PAB silently denies.
+
+### Step 8 — PrincipalSet vs Principal
+
+If permissions seem flaky (works sometimes, fails sometimes; or works for one agent but not an identical sibling), suspect the **PrincipalSet** binding. Move to a **1:1 Principal binding** (bind the specific service account directly) to verify. PrincipalSet propagation can be eventually-consistent in ways that surprise you.
+
+## Quick reference: the checks in order
+
+When triaging a 403, walk these in order — most issues fall out at step 1 or 4:
+
+1. Confirm the 403 in the agent log.
+2. Find the *exact hostname* in the gateway log.
+3. Check IAP audit log: decision, principal, `iamEnforcementMode`, and watch for `unregisteredResource` in the audited resource label.
+3b. If there's no IAP audit entry for the failing call, pull the gateway proxy load-balancer log — the gateway's egress proxy can deny before IAP runs.
+4. Confirm that hostname is registered (registry list + grep).
+5. Check IAM on the registry / specific resource — does the agent's identity (or a principal set it's in) have `roles/iap.egressor`?
+6. Check authz extensions are attached to the gateway, *and* an `authz_policy` actually targets the gateway resource (extension can exist without being applied).
+7. Confirm agent identity has baseline roles (Vertex User, registry viewer, observability, browser).
+7b. Check whether a PAB policy on the principal set is restricting the destination scope (PAB overrides IAM Allow).
+8. If on PrincipalSet bindings and behavior is flaky, switch to direct Principal bindings.
+
+When the symptom matches a known pattern (e.g., startup failure, missing authz_policy targeting the gateway, gateway proxy denial without IAP entry), jump straight to `known-issues.md` — it indexes the recurring failure modes by symptom.

--- a/demos/agent-gateway/.agents/skills/agent-platform-debugger/references/known-issues.md
+++ b/demos/agent-gateway/.agents/skills/agent-platform-debugger/references/known-issues.md
@@ -1,0 +1,126 @@
+# Best Known Issues (BKIs) and limitations
+
+Concrete failure modes that come up repeatedly with the Agent Platform — symptoms and fixes. Read this when the symptom in front of you matches one of these patterns; it's faster than walking the full diagnostic flow.
+
+---
+
+## 1. ReasoningEngine startup: "Failed to convert project number to project ID"
+
+**Symptom:**
+- Log name: `aiplatform.googleapis.com/reasoning_engine_stderr`
+- Error text: `google.api_core.exceptions.Unknown: None` or `Failed to convert project number to project ID.`
+- Happens during ReasoningEngine startup, before any user code runs.
+
+**Cause:** The ReasoningEngine's system identity (the principal set it runs under) lacks `resourcemanager.projects.get`, which the Vertex AI SDK needs to resolve the project name during init.
+
+**Fix:** Grant `roles/browser` to the ReasoningEngine principal set:
+
+```bash
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member="principalSet://agents.global.org-${ORG_ID}.system.id.goog/attribute.platformContainer/aiplatform/projects/${PROJECT_NUMBER}" \
+  --role="roles/browser"
+```
+
+---
+
+## 2. ReasoningEngine startup: "Assembly Service failed to initialize"
+
+**Symptom:** `[1099] ERROR: Assembly Service failed to initialize.` in `reasoning_engine_stderr`.
+
+**Cause:** Generic "init failed" — usually a downstream symptom of either #1 (project-number resolution) or a runtime error in the agent's `set_up()` method.
+
+**Investigation:** Pull all `severity=ERROR` from `reasoning_engine_stderr` around the same timestamp; the actual root cause is in the same window.
+
+---
+
+## 3. Private-preview limit: one Reasoning Engine per project bonded to an Agent Gateway
+
+**Symptom:** Updating a Reasoning Engine to use an Agent Gateway fails with `Internal error encountered` or `The specified parameters are invalid.`
+
+**Cause:** During the private preview, a project can have only one active ReasoningEngine ↔ AgentGateway bonding. A second bonding attempt fails.
+
+**Fix:** Either delete the existing bonded RE / AGW, or reuse the existing AGW for any new REs.
+
+---
+
+## 4. 403 / "Egress request is not authorized" — missing `authz_policy` targeting the gateway
+
+**Symptom:** Audit logs show `GatekeeperAuthorizer.AuthorizeUser` returning `Permission Denied` for `iap.webServiceVersions.egressViaIAP`.
+
+**Cause:** The IAP authz extension exists but no `authz_policy` actually attaches it to the specific Agent Gateway. The extension is configured but the policy that targets the gateway resource is missing.
+
+**Fix:** Verify there's an `authz_policy` in the consumer project that targets the specific `agentGateway` resource. Check with:
+
+```bash
+curl -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
+  "https://networksecurity.googleapis.com/v1alpha1/projects/${PROJECT_ID}/locations/${LOCATION}/authzPolicies"
+```
+
+Look for a policy whose `target.resources[]` includes the gateway's full resource name.
+
+---
+
+## 5. IAP `ENFORCE` mode blocks Agent Engine startup
+
+**Symptom:** Agent Engine instances fail to deploy or start, with 403s in startup logs.
+
+**Cause:** With IAP in `ENFORCE` mode on the Agent Gateway, all egress is denied by default — including the bootstrap calls the agent runtime makes to `cloudresourcemanager`, `aiplatform`, `logging`, `monitoring`, etc. If those endpoints aren't registered AND the agent identity isn't granted `roles/iap.egressor` on them, startup never completes.
+
+**Fix:** Make sure the bootstrap service set is registered in the Agent Registry (see field-manual's "Services that almost always need to be registered" list) and the agent identity has `roles/iap.egressor` on them. While debugging, flipping IAP to `DRY_RUN` lets you observe the failing destinations without blocking startup.
+
+---
+
+## 6. Self-signed / Private CA destinations not supported (early versions)
+
+**Symptom:** Agent fails to connect to internal MCP servers or tools that present self-signed or Private CA-issued certificates.
+
+**Cause:** In private-preview / early Agent Gateway, the gateway's egress proxy can't validate self-signed cert chains.
+
+**Mitigation:** Use publicly-trusted CA certificates for internal MCP servers, or wait for the platform enhancement that adds Private CA trust-anchor support.
+
+
+---
+
+## 7. Principal Access Boundary (PAB) policies overriding IAM Allow
+
+**Symptom:** Agent identity has the right roles bound (`roles/iap.egressor`, `roles/aiplatform.user`, etc.) and the resource is registered correctly, but calls still 403.
+
+**Cause:** A Principal Access Boundary policy is restricting the scope of resources the principal can access. **PAB policies take precedence over IAM Allow policies** — even a correct binding does nothing if a PAB blocks the target resource.
+
+**Investigation:** List PAB policies and their bindings for the agent identity:
+
+```bash
+# List org-wide PAB policies
+gcloud iam principal-access-boundary-policies list \
+  --organization="${ORGANIZATION_ID}" --location=global
+
+# Find what's bound to a specific principal set / agent identity
+gcloud iam policy-bindings search-target-policy-bindings \
+  --project="${PROJECT_ID}" --target="${PRINCIPAL_SET}"
+
+# Inspect a specific PAB
+gcloud iam principal-access-boundary-policies search-policy-bindings "${PAB_POLICY_ID}" \
+  --organization="${ORGANIZATION_ID}" --location=global
+```
+
+**Fix:** Either widen the PAB to include the destination resource, or remove the PAB binding from the agent's principal set if it shouldn't apply.
+
+---
+
+## 8. Gateway proxy denies the request before IAP runs
+
+**Symptom:** Requests fail with no IAP audit log entry — IAP never saw them.
+
+**Cause:** The gateway's underlying egress proxy (a Google-managed Secure Web Proxy instance) enforces a deny-by-default posture *before* IAP authz runs. When the proxy itself denies a call, IAP doesn't get a chance to evaluate, so no IAP audit-log entry is produced for that call.
+
+**Investigation:** Pull the gateway proxy load-balancer logs (the `SECURE_WEB_GATEWAY` label refers to the underlying proxy implementation, not something the customer configures):
+
+```
+jsonPayload.@type="type.googleapis.com/google.cloud.loadbalancing.type.LoadBalancerLogEntry"
+-httpRequest.requestMethod="CONNECT"
+resource.labels.gateway_type="SECURE_WEB_GATEWAY"
+```
+
+Key fields: `httpRequest.status` (look for 403), `jsonPayload.authzPolicyInfo.policies.result` (overall AuthZ result), `httpRequest.requestUrl` (exact destination).
+
+**Fix:** This is almost always upstream — usually a missing or misconfigured Agent Registry entry, an `authz_policy` that doesn't target the gateway, or a recent platform-side change. Walk the registry-verification and authz-wiring steps in `field-manual.md`. The proxy's policy itself is Google-managed and derived from your registry/policy state; you don't edit it directly.

--- a/demos/agent-gateway/.agents/skills/agent-platform-debugger/references/policies.md
+++ b/demos/agent-gateway/.agents/skills/agent-platform-debugger/references/policies.md
@@ -1,0 +1,745 @@
+# Agent Platform Policies — Debugging Reference
+
+Reference for diagnosing IAM, IAP, and Agent Gateway policy denials in the
+**GCP Gemini Enterprise Agent Platform**. Read this when an agent gets a 403,
+when an MCP/agent/endpoint call is silently dropped, or when a freshly applied
+policy "doesn't take."
+
+---
+
+## TL;DR for debugging
+
+1. **Agent Gateway uses IAP under the hood.** Policy denials surface as either
+   IAP 403s or as `protoPayload.serviceName="iap.googleapis.com"` audit log
+   entries. Always start in the IAP audit logs, not the agent runtime logs.
+   (Source: policies/overview, policies/test-policies)
+
+2. **The role that allows agent egress is `roles/iap.egressor`** (display name
+   "IAP-secured Egressor"). If an agent gets `Egress request is not authorized`,
+   it is missing this role on the target resource — every other diagnosis is
+   downstream of this. (Source: policies/assign-identity-iam)
+
+3. **Policies bind to Agent Registry resources, not to the agent.** The binding
+   is set on the *target* (the Agent Registry, an MCP server, a destination
+   agent, or an endpoint). The *member* is the source agent's principal.
+   (Source: policies/overview, IAP agent overview)
+
+4. **Three layers, all must allow:** (a) IAM allow/deny on the Agent Registry
+   resource, (b) IAP ingress policy on the destination, (c) underlying
+   resource IAM (e.g. `roles/run.invoker` on the Cloud Run MCP server for the
+   IAP service agent). Missing any one produces a 403; the layers are NOT
+   substitutes. (Source: policies/overview, policies/assign-identity-iam)
+
+5. **Start in `DRY_RUN` mode.** In DRY_RUN, IAP writes denial entries to Cloud
+   Audit Logs without blocking traffic. This is the *only* way to enumerate
+   what would break before flipping `ENFORCE`. (Source: policies/overview,
+   policies/test-policies)
+
+6. **`principal://` is exact; `principalSet://` is a hierarchy.** `principal://`
+   binds a single agent. `principalSet://` binds a class of agents (e.g. "all
+   reasoning engines in project 1234"). PrincipalSet bindings are convenient
+   but propagate more slowly and depend on the agent's container attribute
+   being correctly stamped at registration. (Source: policies/assign-identity-iam)
+
+7. **Agent identity is SPIFFE-formatted.** Vertex AI / Gemini Enterprise agents
+   use a `principal://agents.global.org-<ORG_ID>.system.id.goog/...` URI;
+   DIY (Cloud Run) agents use a workload-identity-pool URI. Mixing the two
+   forms in a single binding is a common source of "I gave it the role and it
+   still 403s." (Source: policies/assign-identity-iam)
+
+8. **CEL conditions are evaluated per-request.** A binding with a condition
+   that references `mcp.toolName` or `mcp.tool.isReadOnly` will deny when the
+   attribute is absent or false. Suspect conditions before suspecting bindings.
+   (Source: policies/overview)
+
+9. **The Cloud Run MCP server itself needs `roles/run.invoker` granted to the
+   IAP service agent** (`service-PROJECT_NUMBER@gcp-sa-iap.iam.gserviceaccount.com`).
+   This is independent of the agent's `iap.egressor` binding. (Source:
+   policies/assign-identity-iam)
+
+10. **`gcloud beta iap web get-iam-policy` is your primary inspection tool.**
+    Use `--resource-type=AgentRegistry` (or `--agent`/`--mcpServer`/`--endpoint`)
+    to see the effective policy on the right scope. (Source: policies/test-policies)
+
+---
+
+## 1. What "policies" means in the Agent Platform
+
+Source:
+<https://docs.cloud.google.com/gemini-enterprise-agent-platform/govern/policies/overview>
+
+Agent Platform layers **two complementary policy systems**:
+
+### 1a. IAM Policies (allow / deny)
+
+- Enforced by **Agent Gateway** via **Identity-Aware Proxy (IAP)**.
+- Control agent-to-service communication (agent → MCP server, agent → agent,
+  agent → endpoint).
+- Use standard IAM bindings (member / role / condition) but applied through
+  the IAP API surface (`gcloud beta iap web set-iam-policy`).
+- **The role for outbound agent traffic is `roles/iap.egressor`.**
+- Conditions use CEL with agent-aware variables.
+
+### 1b. Semantic Governance Policies (SGP)
+
+- A **natural language** policy layer that uses Natural Language Constraints
+  (NLC) to align tool invocations with user intent and business rules.
+- Operates on the LLM call shape, not the network shape. Out of scope for
+  most 403-class debugging — if you're seeing a 403 on the wire, it is IAM
+  or IAP, not SGP.
+
+### 1c. The IAP enforcement plane
+
+- **mTLS** terminates at Agent Gateway. Both sides authenticate with
+  X.509 certificates provisioned for the agent identity.
+- **DPoP (Demonstrable Proof of Possession)** binds tokens to the
+  certificate so a stolen token can't be replayed.
+- The agent's identity travels in the request (not just a bearer token); IAP
+  evaluates the IAM policy on the destination resource against that identity.
+
+### 1d. How they layer
+
+For an agent call to succeed, **all three** of the following must allow:
+
+```
+[ Source Agent ]
+       │
+       │ mTLS + DPoP, identity = principal://...
+       ▼
+[ Agent Gateway / IAP ]   ← Layer 1: IAM allow policy on the Agent Registry
+       │                              resource grants roles/iap.egressor
+       │                              to the source agent's principal.
+       │
+       │ Forwarded request, signed by IAP service agent
+       ▼
+[ Underlying resource ]   ← Layer 2: IAP ingress policy on the destination
+       │                              (MCP server / endpoint / agent).
+       │
+       │                  ← Layer 3: The destination's *native* IAM
+       ▼                              (e.g. roles/run.invoker on a Cloud Run
+                                      service granted to
+                                      service-<PROJECT_NUMBER>@gcp-sa-iap.iam.gserviceaccount.com)
+```
+
+A missing role at **any** layer produces a 403. Always check all three.
+
+---
+
+## 2. Assigning agent identity in IAM
+
+Source:
+<https://docs.cloud.google.com/gemini-enterprise-agent-platform/govern/policies/assign-identity-iam>
+
+### 2a. Identity formats — pick the right one
+
+**Vertex AI Agent Engine + Gemini Enterprise agents** (the managed runtimes):
+
+```
+principal://TRUST_DOMAIN/AGENT_UNIQUE_IDENTIFIER
+```
+
+Concrete example:
+
+```
+principal://agents.global.org-123456789012.system.id.goog/resources/aiplatform/projects/9876543210/locations/us-central1/reasoningEngines/my-test-agent
+```
+
+The `TRUST_DOMAIN` is per-organization: `agents.global.org-<ORG_ID>.system.id.goog`.
+
+**DIY agents (anything you deploy on Cloud Run, GKE, etc.):**
+
+```
+principal://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/AGENT_SERVICE_ACCOUNT_IDENTIFIER
+```
+
+Concrete example:
+
+```
+principal://iam.googleapis.com/projects/1234567890/locations/global/workloadIdentityPools/my-agent-identity/subject/ns/default/sa/my-agent
+```
+
+Note this is a **workload identity pool** principal, not a plain
+`serviceAccount:foo@...` member. Granting the role to the bare service account
+will **not** authorize the agent through Agent Gateway.
+
+### 2b. Roles you (the operator) need to manage policies
+
+| Role                                       | Purpose                                          |
+| ------------------------------------------ | ------------------------------------------------ |
+| `roles/iap.admin`                          | Set/get IAP IAM policies                         |
+| `roles/agentregistry.viewer`               | Browse the agent registry                        |
+| `roles/resourcemanager.projectIamAdmin`    | Manage project IAM bindings                      |
+| `roles/networksecurity.admin`              | Configure Agent Gateway network policies         |
+| `roles/serviceextensions.admin`            | Manage service extensions used by Agent Gateway  |
+
+### 2c. The role you grant to the agent
+
+```
+roles/iap.egressor    # display name: "IAP-secured Egressor"
+```
+
+This is the **only** role that authorizes an agent to egress through Agent
+Gateway. Granting `roles/editor` or even `roles/owner` to the agent's
+principal will not substitute — IAP specifically checks for `iap.egressor`.
+
+### 2d. Minimal binding (agent → all resources in the registry)
+
+`agents-iap-policy.json`:
+
+```json
+{
+  "policy": {
+    "bindings": [
+      {
+        "role": "roles/iap.egressor",
+        "members": [
+          "principal://agents.global.org-123456789012.system.id.goog/resources/aiplatform/projects/9876543210/locations/us-central1/reasoningEngines/my-test-agent"
+        ]
+      }
+    ]
+  }
+}
+```
+
+Apply at the **Agent Registry** scope:
+
+```bash
+gcloud beta iap web set-iam-policy agents-iap-policy.json \
+  --project=PROJECT_ID \
+  --resource-type=AgentRegistry \
+  --region=REGION
+```
+
+The same command takes `--folder=FOLDER_ID` or `--organization=ORG_ID` instead
+of `--project` if you want a wider scope.
+
+### 2e. Per-resource binding (agent → one MCP server)
+
+Same JSON shape, narrower scope:
+
+```bash
+gcloud beta iap web set-iam-policy mcp-iap-policy.json \
+  --project=PROJECT_ID \
+  --resource-type=AgentRegistry \
+  --region=REGION \
+  --mcpServer=MCP_SERVER_NAME
+```
+
+The available narrow flags are `--agent`, `--mcpServer`, `--endpoint`. Pick
+the one that matches the destination type.
+
+### 2f. Conditional binding (CEL) — restrict to read-only tool calls
+
+```json
+{
+  "policy": {
+    "bindings": [
+      {
+        "role": "roles/iap.egressor",
+        "members": [
+          "principal://agents.global.org-123456789012.system.id.goog/resources/aiplatform/projects/9876543210/locations/us-central1/reasoningEngines/ae-agent"
+        ],
+        "condition": {
+          "title": "Allow AE Agent Read-Only Egress to GitHub MCP server",
+          "description": "Only read-only GitHubTool calls",
+          "expression": "api.getAttribute('iap.googleapis.com/mcp.toolName', '') == 'GitHubTool' && api.getAttribute('iap.googleapis.com/mcp.tool.isReadOnly', false) == true"
+        }
+      }
+    ]
+  }
+}
+```
+
+Available CEL attributes (non-exhaustive):
+
+- `mcp.toolName` — the tool the agent is invoking
+- `mcp.resourceName`
+- `mcp.method`
+- `mcp.tool.isReadOnly` — boolean
+- `mcp.tool.isDestructive` — boolean
+- `mcp.tool.isIdempotent` — boolean
+- `mcp.tool.isOpenWorld` — boolean
+- `request.auth.type`
+
+If a condition's expression evaluates to anything other than `true`, the
+binding does not match and the request is denied (assuming no other matching
+binding allows it).
+
+### 2g. PrincipalSet bindings — when to use, when to avoid
+
+`principalSet://` lets you bind a *set* of agents in one go. Example: every
+reasoning engine under project 1234 in the org:
+
+```json
+{
+  "policy": {
+    "bindings": [
+      {
+        "role": "roles/iap.egressor",
+        "members": [
+          "principalSet://agents.global.org-ORGANIZATION_ID.system.id.goog/attribute.platformContainer/aiplatform/projects/1234"
+        ]
+      }
+    ]
+  }
+}
+```
+
+**When to use PrincipalSet:**
+
+- Granting access to a class of agents you cannot enumerate up front
+  (e.g. all agents the data-science org will ever deploy in project 1234).
+- Coarse-grained "this whole project's agents may call this MCP server."
+
+**When PrincipalSet causes pain (debug accordingly):**
+
+- **Membership depends on attributes stamped at agent registration.** A new
+  agent that didn't pick up `attribute.platformContainer` correctly will not
+  be a member of the set, even if it "looks the same" as other agents. If a
+  brand-new agent gets `Egress request is not authorized` while existing
+  agents work, suspect the attribute stamp before suspecting the policy.
+- **Slower propagation than direct `principal://` bindings.** PrincipalSet
+  membership is computed; direct principal bindings are matched. If you just
+  added the binding and a request still fails, give it a few minutes and
+  re-check before re-tweaking.
+- **No condition support for membership** — you can attach a CEL condition to
+  the binding, but you can't use CEL to define who's in the set.
+- **Harder to audit.** Audit logs show the *concrete* principal of the caller,
+  not the PrincipalSet that allowed it. To prove which binding authorized a
+  given call, you have to manually re-derive set membership.
+
+**Rule of thumb:** for a small fixed roster of agents, prefer multiple
+`principal://` entries in one binding. Reach for `principalSet://` only when
+the roster is open-ended.
+
+### 2h. Granting Cloud Run MCP servers to the IAP service agent
+
+A Cloud Run-backed MCP server is invoked **by IAP**, not by the agent
+directly. IAP signs the forwarded request as the IAP service agent, so the
+Cloud Run service must let that service agent in:
+
+```bash
+gcloud beta run services add-iam-policy-binding SERVICE_NAME \
+  --member='serviceAccount:service-PROJECT_NUMBER@gcp-sa-iap.iam.gserviceaccount.com' \
+  --role='roles/run.invoker'
+```
+
+If this is missing, the symptom is a 403 from Cloud Run that surfaces to the
+agent as a generic upstream failure — and **the IAP audit log will look
+clean**, because IAP itself authorized the call. This is the most common
+"my IAM policy looks right but it still 403s" cause.
+
+---
+
+## 3. Testing and verifying policies
+
+Source:
+<https://docs.cloud.google.com/gemini-enterprise-agent-platform/govern/policies/test-policies>
+
+### 3a. Always validate in DRY_RUN first
+
+Agent Gateway has two enforcement modes:
+
+- **`DRY_RUN`** — IAP logs disallowed communications to Cloud Audit Logs but
+  **does not** block them. Traffic flows. Use this to enumerate every binding
+  you're missing before flipping the switch.
+- **`ENFORCE`** — Disallowed communications are blocked with a 403.
+
+Workflow:
+
+1. Define your policies.
+2. Set the gateway to `DRY_RUN`.
+3. Exercise your agents (run real workloads or a test harness).
+4. Pull DRY_RUN denial entries from Cloud Audit Logs.
+5. Add bindings to cover legitimate denials. Repeat until clean.
+6. Flip to `ENFORCE`.
+
+### 3b. Inspect the effective IAM policy
+
+```bash
+# Registry-wide
+gcloud beta iap web get-iam-policy \
+  --project=PROJECT_ID \
+  --resource-type=AgentRegistry \
+  --region=REGION
+
+# Per resource
+gcloud beta iap web get-iam-policy \
+  --project=PROJECT_ID \
+  --resource-type=AgentRegistry \
+  --region=REGION \
+  --mcpServer=MCP_SERVER_NAME
+```
+
+Compare the printed `bindings[]` to what you expect. The exact `members`
+string must match the agent's principal URI **byte-for-byte** — a typo in the
+trust domain or an off-by-one in the project number is enough to fail.
+
+### 3c. Read the audit logs
+
+The single most useful filter for any Agent Gateway / IAP debugging session:
+
+```
+protoPayload.serviceName="iap.googleapis.com"
+```
+
+Combined with `severity=ERROR` and a recent time window, this surfaces
+denials. In the Logs Explorer:
+
+```
+protoPayload.serviceName="iap.googleapis.com"
+severity>=WARNING
+timestamp>="2026-05-12T00:00:00Z"
+```
+
+Useful payload fields to project on:
+
+- `protoPayload.authenticationInfo.principalEmail` — for SA-backed callers
+- `protoPayload.authenticationInfo.principalSubject` — for SPIFFE / workload
+  identity callers (this is where the agent's `principal://...` ends up)
+- `protoPayload.authorizationInfo[].resource` — the destination
+- `protoPayload.authorizationInfo[].permission` — typically `iap.webServices.accessViaIAP`
+  or an `iap.tunnel*` permission
+- `protoPayload.authorizationInfo[].granted` — boolean
+- `protoPayload.status.code` and `protoPayload.status.message` — the deny
+  reason (this is where `Egress request is not authorized` shows up)
+- `protoPayload.metadata` — DRY_RUN entries land here with extra context
+  including the binding(s) that *would* have been required
+
+To filter to **policy-denied** entries specifically, the Logs Explorer
+"Log name" facet has a `policy` denied audit log stream — select it from the
+Query builder pane.
+
+To see Data Access logs (read calls, etc.), Data Access audit logs must be
+enabled for the service. The viewer needs `roles/logging.privateLogViewer`
+to see them in the console.
+
+### 3d. Trigger and observe — the standard egress test
+
+```
+1. From the source agent, make a call that targets the MCP server / agent /
+   endpoint you're trying to authorize.
+2. tail the audit logs:
+     gcloud logging read \
+       'protoPayload.serviceName="iap.googleapis.com"' \
+       --project=PROJECT_ID \
+       --limit=20 \
+       --order=desc
+3. Find the entry matching your principal and target.
+4. If granted=false, read status.message and authorizationInfo[].permission
+   to identify the missing role.
+```
+
+### 3e. Trigger and observe — the standard ingress test
+
+For ingress (an external client → an agent through IAP), the failure mode is
+typically a 403 in the **client's** response, not in the audit logs.
+
+```
+1. Issue the request from the external client.
+2. If you get HTTP 403 with body containing "You don't have access" or
+   similar, IAP rejected it.
+3. Check the IAP audit log filtered as above.
+4. Verify the client's identity has roles/iap.httpsResourceAccessor (for
+   web/HTTP) or roles/iap.tunnelResourceAccessor (for tunnel) on the
+   destination resource.
+```
+
+### 3f. IAM Policy Troubleshooter
+
+For any single denial, the **IAM Policy Troubleshooter** answers "why was X
+denied permission Y on resource Z?" by walking up the resource hierarchy and
+listing every binding considered.
+
+```
+Console → IAM & Admin → Policy Troubleshooter
+  Principal:  <copy from authenticationInfo.principalSubject>
+  Resource:   <full resource name from authorizationInfo.resource>
+  Permission: iap.webServices.accessViaIAP   (or the specific iap.tunnel*)
+```
+
+For Agent Platform principals, paste the full `principal://...` URI as the
+principal — Policy Troubleshooter accepts SPIFFE-formatted principals.
+
+---
+
+## 4. Common 403 / "Egress request is not authorized" causes
+
+Source: synthesis of all three docs.
+
+The error message you'll see in the audit log is literally:
+
+```
+Egress request is not authorized
+```
+
+Below: the symptom → root cause → fix table for the cases I see most.
+
+### 4a. Missing `roles/iap.egressor` binding
+
+**Symptom:** Audit log entry with
+`protoPayload.status.message = "Egress request is not authorized"` and
+`authorizationInfo[].granted = false` for permission `iap.webServices.accessViaIAP`.
+
+**Cause:** The agent's principal has no `roles/iap.egressor` binding on the
+destination (or on the Agent Registry containing it).
+
+**Fix:** Add the binding at the appropriate scope — see §2d / §2e.
+
+### 4b. Wrong principal format
+
+**Symptom:** Same audit log line as above. `gcloud beta iap web get-iam-policy`
+shows a binding "for the agent" but the binding actually has the wrong member
+URI.
+
+**Cause:** Bound `serviceAccount:my-agent@project.iam.gserviceaccount.com`
+instead of the workload-identity-pool URI; or used the Vertex `principal://`
+format for a DIY agent (or vice versa); or the `TRUST_DOMAIN` has the wrong
+`org-<ORG_ID>` segment; or the project number in the URI is wrong.
+
+**Fix:** Re-derive the agent's principal from the docs (§2a) and replace the
+member string verbatim.
+
+### 4c. Cloud Run MCP server doesn't trust IAP
+
+**Symptom:** IAP audit log shows the call was **allowed** (granted=true), but
+the agent reports an upstream 403. Cloud Run logs show
+`The request was not authenticated` or a missing `run.invoker` permission.
+
+**Cause:** The IAP service agent
+(`service-<PROJECT_NUMBER>@gcp-sa-iap.iam.gserviceaccount.com`) doesn't have
+`roles/run.invoker` on the Cloud Run service backing the MCP server.
+
+**Fix:**
+
+```bash
+gcloud beta run services add-iam-policy-binding SERVICE_NAME \
+  --member='serviceAccount:service-PROJECT_NUMBER@gcp-sa-iap.iam.gserviceaccount.com' \
+  --role='roles/run.invoker'
+```
+
+### 4d. CEL condition evaluates to false
+
+**Symptom:** The binding *exists* and the principal *matches*, but the
+audit log shows `granted=false` with metadata indicating a condition did
+not pass.
+
+**Cause:** A condition like
+`api.getAttribute('iap.googleapis.com/mcp.tool.isReadOnly', false) == true`
+denies any call where the attribute is missing or the tool isn't tagged
+read-only. New tools without the `isReadOnly` annotation hit this.
+
+**Fix:** Either tag the tool correctly in the MCP server's manifest, or
+broaden / remove the condition for that binding.
+
+### 4e. PrincipalSet doesn't include the agent
+
+**Symptom:** Brand-new agent gets `Egress request is not authorized` even
+though sibling agents in the same project succeed against the same target.
+
+**Cause:** The PrincipalSet is keyed off `attribute.platformContainer`
+(or similar) and the new agent doesn't have that attribute set. This usually
+means the agent was registered with a non-standard identifier, or the
+registration is incomplete.
+
+**Fix:** Re-register the agent through the supported runtime; or, as a
+short-term unblock, add a direct `principal://...` binding for that one
+agent to confirm the rest of the policy plane is correct.
+
+### 4f. Wrong scope on `set-iam-policy`
+
+**Symptom:** Policy looks correct in the JSON, `gcloud` returns success, but
+the call still 403s.
+
+**Cause:** Bound the policy at `--resource-type=AgentRegistry` (registry-wide)
+when the destination is governed by a per-resource policy that lacks the
+binding; or vice versa. Per-resource policies don't *inherit* from registry-
+level policies — they replace them for that resource.
+
+**Fix:** Decide on the scope. For the common case — "this agent should reach
+everything in the registry" — set at `--resource-type=AgentRegistry` and
+ensure no narrower per-resource policy is overriding it. Inspect with
+`get-iam-policy` at *both* scopes.
+
+### 4g. Wrong scope on the principal URI for Vertex agents
+
+**Symptom:** Audit log shows the principal is
+`principal://...reasoningEngines/<engine-id>` but your binding has
+`principal://...reasoningEngines/<wrong-engine-id>`.
+
+**Cause:** Re-deployed the agent and got a new reasoning engine ID; the
+policy still references the old one.
+
+**Fix:** Look up the current reasoning engine ID
+(`gcloud ai reasoning-engines list`) and update the binding member.
+
+### 4h. ENFORCE flipped before DRY_RUN was clean
+
+**Symptom:** Sudden burst of `Egress request is not authorized` on calls
+that "used to work."
+
+**Cause:** Gateway was just switched to `ENFORCE` and the DRY_RUN denial set
+was never fully addressed.
+
+**Fix:** Flip back to `DRY_RUN`, drain the denial backlog
+(`severity>=WARNING protoPayload.serviceName="iap.googleapis.com"` over the
+last hour), add bindings, re-flip.
+
+---
+
+## 5. The IAP egressor role — exact placement
+
+Source:
+<https://docs.cloud.google.com/gemini-enterprise-agent-platform/govern/policies/assign-identity-iam>
+
+The Agent Platform's egress role is `roles/iap.egressor`. Note this is **not**
+the same role used for traditional IAP TCP forwarding (which is
+`roles/iap.tunnelResourceAccessor`). Don't confuse the two:
+
+| Role                                  | Purpose                                        |
+| ------------------------------------- | ---------------------------------------------- |
+| `roles/iap.egressor`                  | Authorizes an **agent** to egress through Agent Gateway. This is what you want for Agent Platform. |
+| `roles/iap.tunnelResourceAccessor`    | Authorizes a **user/SA** to use TCP/SSH tunneling through IAP to a VM. Unrelated to Agent Gateway egress. |
+| `roles/iap.httpsResourceAccessor`     | Authorizes a user to access an IAP-protected web app (ingress). |
+
+**Where to grant `roles/iap.egressor`:**
+
+- **Registry-wide** (most common): bind at `--resource-type=AgentRegistry`
+  with no narrower selector. The agent can then reach any registered MCP
+  server / agent / endpoint in the registry.
+- **Per resource** (least privilege): bind at `--resource-type=AgentRegistry`
+  with `--mcpServer=NAME` (or `--agent=NAME` / `--endpoint=NAME`). The agent
+  can only reach that one resource.
+
+The binding always lives on the **destination** scope — never on the source
+agent. The source agent appears as the *member*, not as the resource.
+
+You can also bind at `--folder=FOLDER_ID` or `--organization=ORG_ID` for
+multi-project setups. Inheritance follows the standard IAM resource hierarchy.
+
+---
+
+## 6. Quick command cheat sheet
+
+```bash
+# --- Inspect ---
+
+# Effective policy on the registry
+gcloud beta iap web get-iam-policy \
+  --project=PROJECT_ID \
+  --resource-type=AgentRegistry \
+  --region=REGION
+
+# Effective policy on one MCP server
+gcloud beta iap web get-iam-policy \
+  --project=PROJECT_ID \
+  --resource-type=AgentRegistry \
+  --region=REGION \
+  --mcpServer=MCP_SERVER_NAME
+
+# --- Apply ---
+
+# Set policy registry-wide
+gcloud beta iap web set-iam-policy agents-iap-policy.json \
+  --project=PROJECT_ID \
+  --resource-type=AgentRegistry \
+  --region=REGION
+
+# --- Cloud Run MCP server prerequisite ---
+
+gcloud beta run services add-iam-policy-binding SERVICE_NAME \
+  --member='serviceAccount:service-PROJECT_NUMBER@gcp-sa-iap.iam.gserviceaccount.com' \
+  --role='roles/run.invoker' \
+  --region=REGION
+
+# --- Tail audit logs for denials ---
+
+gcloud logging read \
+  'protoPayload.serviceName="iap.googleapis.com" severity>=WARNING' \
+  --project=PROJECT_ID \
+  --limit=20 \
+  --order=desc \
+  --format='value(timestamp, protoPayload.authenticationInfo.principalSubject, protoPayload.authorizationInfo[0].resource, protoPayload.status.message)'
+
+# --- Same, in Logs Explorer query language ---
+# protoPayload.serviceName="iap.googleapis.com"
+# severity>=WARNING
+# timestamp>="2026-05-12T00:00:00Z"
+```
+
+---
+
+## 7. Debugging flowchart
+
+```
+Agent call fails / hangs
+        │
+        ▼
+Is there an entry in the IAP audit log?
+  (filter: protoPayload.serviceName="iap.googleapis.com")
+        │
+   ┌────┴────┐
+  yes        no  ─► Check the *destination* IAM (Cloud Run roles/run.invoker
+   │                for the IAP service agent), or the destination's own
+   │                logs. IAP didn't reject the call; something downstream did.
+   │                (Cause 4c.)
+   ▼
+Does it say "Egress request is not authorized"?
+        │
+   ┌────┴────┐
+  yes        no  ─► Read status.message; usually a clear hint
+   │                (token expired, mTLS handshake, DPoP mismatch, etc.).
+   ▼
+Does authorizationInfo[].granted == false?
+        │
+   ┌────┴────┐
+  yes        no  ─► Granted but still failed → DRY_RUN entry; gateway
+   │                logged what *would* be denied. No action required if
+   │                you're in DRY_RUN intentionally.
+   ▼
+Get the principal from authenticationInfo.principalSubject.
+Get the resource from authorizationInfo[0].resource.
+        │
+        ▼
+gcloud beta iap web get-iam-policy on that resource scope.
+        │
+        ▼
+Is there a binding for roles/iap.egressor with that exact principal
+(or a principalSet that contains it)?
+        │
+   ┌────┴────┐
+  no         yes
+   │          │
+   │          ▼
+   │     Does the binding have a condition?
+   │          │
+   │     ┌────┴────┐
+   │    yes        no  ─► Principal mismatch: typo, wrong format
+   │     │                (Vertex vs DIY), wrong project number,
+   │     │                or PrincipalSet missing attribute. (Causes 4b, 4e, 4g.)
+   │     ▼
+   │  Evaluate the CEL with the actual request attributes.
+   │  Does it return true?
+   │     │
+   │ ┌───┴───┐
+   │ no     yes  ─► Should have allowed. Check scope: maybe a per-resource
+   │ │              policy is overriding the registry-wide one. (Cause 4f.)
+   │ ▼
+   │ Condition is the cause. Fix the tool annotation or
+   │ broaden the condition. (Cause 4d.)
+   ▼
+Add the missing binding. (Cause 4a.)
+```
+
+---
+
+## 8. Sources
+
+- Policies overview:
+  <https://docs.cloud.google.com/gemini-enterprise-agent-platform/govern/policies/overview>
+- Assign agent identity in IAM:
+  <https://docs.cloud.google.com/gemini-enterprise-agent-platform/govern/policies/assign-identity-iam>
+- Test policies:
+  <https://docs.cloud.google.com/gemini-enterprise-agent-platform/govern/policies/test-policies>
+- Agent Gateway and IAP overview (cross-ref):
+  <https://docs.cloud.google.com/iap/docs/agent-overview>

--- a/demos/agent-gateway/docs/troubleshooting.md
+++ b/demos/agent-gateway/docs/troubleshooting.md
@@ -1,0 +1,644 @@
+# Troubleshoot the Gemini Enterprise Agent Platform
+
+This guide helps you diagnose authorization and connectivity failures on Google Cloud's Gemini Enterprise Agent Platform — Agent Gateway, Agent Registry, Agent Identity, agent policies, and Identity-Aware Proxy (IAP) delegated authorization.
+
+This document is the human-readable companion to the `agent-platform-debugger` A skill at `.agents/skills/agent-platform-debugger/`. The skill packages the same knowledge for AI-assisted debugging; this guide presents it for someone reading top-to-bottom.
+
+> **Scope.** This guide covers the Gemini Enterprise Agent Platform stack. It does not cover general Google Cloud IAM debugging unrelated to the platform, plain VPC Service Controls perimeters, or Cloud Run authentication outside the agent context.
+
+## Contents
+
+- [Before you begin](#before-you-begin)
+- [How agent egress is authorized](#how-agent-egress-is-authorized)
+- [Hostname permutations are the most common cause](#hostname-permutations-are-the-most-common-cause)
+- [Diagnose a 403 from an agent](#diagnose-a-403-from-an-agent)
+- [Common issues](#common-issues)
+- [Reference](#reference)
+
+---
+
+## Before you begin
+
+### Permissions you need to triage
+
+To work through this guide, your user account or service account needs read access to the following surfaces:
+
+- `roles/logging.viewer` — to read ReasoningEngine, gateway, and IAP audit logs in Cloud Logging.
+- `roles/iap.settingsAdmin` — to read IAM policies on Agent Registry resources through the IAP API.
+- `roles/agentregistry.viewer` — to list registered endpoints, MCP servers, and agents.
+- `roles/networkservices.viewer` — to inspect Agent Gateway and authz policies.
+- `roles/iam.securityReviewer` — to read IAM bindings and Principal Access Boundary (PAB) policies at the project and organization scope.
+
+You also need the Google Cloud CLI (`gcloud`) installed, with `gcloud beta` and `gcloud alpha` components available, and `curl` for direct API calls.
+
+### Variables used in this guide
+
+The shell snippets in this guide use these variables. Set them once for your environment before running the commands.
+
+| Variable | Description | Example |
+|---|---|---|
+| `PROJECT_ID` | The consumer project that runs the agent. | `my-agent-project` |
+| `PROJECT_NUMBER` | Numeric ID of the same project. | `123456789012` |
+| `LOCATION` | Region of the agent and registry. | `us-central1` |
+| `REGION` | Region of the Agent Gateway (often the same as `LOCATION`). | `us-central1` |
+| `AGENT_ID` | The Reasoning Engine ID. | `1234567890123456789` |
+| `AGENT_GATEWAY_NAME` | Name of the Agent Gateway resource. | `prod-agent-gateway` |
+| `ENDPOINT_ID` | An Agent Registry endpoint ID. | `aiplatform-us-central1` |
+| `MCP_SERVER_NAME` | An Agent Registry MCP server name. | `mcp-customer-data` |
+| `ORGANIZATION_ID` | Numeric Google Cloud organization ID. | `987654321098` |
+| `PRINCIPAL_SET` | A `principalSet://...` URI for the agent identity. | (see [Glossary](#glossary)) |
+
+---
+
+## How agent egress is authorized
+
+Every outbound call from an agent traverses several layers of authorization. Each layer denies by default. A missing entry at any layer returns the same generic 403 response, which is why diagnosis hinges on identifying which layer rejected the call.
+
+### Authorization layers
+
+```mermaid
+flowchart TD
+    A["Agent (Reasoning Engine)"] --> B["Agent Gateway"]
+    B --> C{"authz_policy targets<br/>this gateway?"}
+    C -- "No" --> D["Denied at gateway"]
+    C -- "Yes" --> E["Service extension<br/>calls IAP"]
+    E --> F{"Hostname registered<br/>in Agent Registry?"}
+    F -- "No" --> G["Denied: unregisteredResource"]
+    F -- "Yes" --> H{"IAM grants<br/>roles/iap.egressor?"}
+    H -- "No" --> I["IAP denies"]
+    H -- "Yes" --> J{"Principal Access Boundary<br/>allows destination?"}
+    J -- "No" --> K["PAB silently denies"]
+    J -- "Yes" --> L["Request reaches<br/>destination service"]
+```
+
+The layers, in order:
+
+1. **Agent Registry.** The destination must be registered as an endpoint, MCP server, or agent. Anything not registered is denied.
+2. **Agent Gateway.** The gateway sits in front of the agent's egress. An `authz_policy` must explicitly *target* the gateway resource, otherwise the configured authorization extension is not applied.
+3. **Service extension (delegated authorization).** The gateway calls IAP through a service extension to make an allow or deny decision.
+4. **IAP and IAM.** The agent's identity must hold `roles/iap.egressor` on the registered resource, either directly or through a principal set the agent belongs to.
+5. **Principal Access Boundary (PAB).** A PAB policy on the principal set can restrict which resources its members reach. **PAB takes precedence over IAM Allow.** A correct binding does nothing if a PAB scopes the principal away from the target.
+
+> **Under the hood.** Agent Gateway runs on a Google-managed Secure Web Proxy instance that provides the egress proxy capabilities. You do not configure the proxy directly. Its rules derive from your Agent Registry entries and authz policies. Denials from the proxy layer surface in load-balancer logs (see [Log queries](#log-queries)), which is useful when a request is blocked before IAP gets a chance to make an authorization decision.
+
+### What a denial looks like
+
+The canonical 403 in agent logs is:
+
+```json
+{"code": 403, "message": "403 Forbidden. {'message': 'Egress request is not authorized.', 'status': 'Forbidden'}"}
+```
+
+To triage a 403, identify which layer rejected the call. The flow in [Diagnose a 403 from an agent](#diagnose-a-403-from-an-agent) walks each layer in most-likely-cause order.
+
+---
+
+## Hostname permutations are the most common cause
+
+A Google Cloud API such as `aiplatform.googleapis.com` is reachable through many distinct hostnames. The agent's SDK calls one of them depending on the SDK version, regional client configuration, or whether mTLS is in play.
+
+### Why one API has many hostnames
+
+For service `aiplatform` in region `us-central1`, all of the following resolve to Vertex AI:
+
+```mermaid
+graph LR
+    api(["aiplatform service<br/>(one logical API)"])
+    api --> h1["aiplatform.googleapis.com<br/>(base)"]
+    api --> h2["aiplatform.mtls.googleapis.com<br/>(base + mTLS)"]
+    api --> h3["us-central1-aiplatform.googleapis.com<br/>(locational)"]
+    api --> h4["us-central1-aiplatform.mtls.googleapis.com<br/>(locational + mTLS)"]
+    api --> h5["aiplatform.us-central1.rep.googleapis.com<br/>(REP public)"]
+    api --> h6["aiplatform.us-central1.p.rep.googleapis.com<br/>(REP private/PSC)"]
+```
+
+| Form | Example |
+|---|---|
+| Base | `aiplatform.googleapis.com` |
+| Base + mTLS | `aiplatform.mtls.googleapis.com` |
+| Locational | `us-central1-aiplatform.googleapis.com` |
+| Locational + mTLS | `us-central1-aiplatform.mtls.googleapis.com` |
+| Regional Endpoint Proxy (public) | `aiplatform.us-central1.rep.googleapis.com` |
+| Regional Endpoint Proxy (private, PSC) | `aiplatform.us-central1.p.rep.googleapis.com` |
+
+The Agent Gateway matches hostnames exactly. If you registered only `aiplatform.googleapis.com` but the SDK calls `us-central1-aiplatform.googleapis.com`, the request is denied — even though the API is technically registered. The gateway treats it as a different hostname. Unregistered hostnames resolve to `unregisteredResource` and are denied.
+
+When investigating a 403, always read the exact hostname the agent called from the gateway log, then verify that hostname is registered.
+
+### Register every permutation
+
+A registration script that covers the full set looks like this:
+
+```bash
+reg_svc "${id}"                   "${name}"                "https://${id}.googleapis.com"
+reg_svc "${id}-mtls"              "${name} mTLS"           "https://${id}.mtls.googleapis.com"
+reg_svc "${LOCATION}-${id}"       "${name} Locational"     "https://${LOCATION}-${id}.googleapis.com"
+reg_svc "${LOCATION}-${id}-mtls"  "${name} Locational mTLS" "https://${LOCATION}-${id}.mtls.googleapis.com"
+reg_svc "${id}-${LOCATION}-rep"   "${name} Regional (REP)" "https://${id}.${LOCATION}.rep.googleapis.com"
+```
+
+Add the PSC REP form (`https://${id}.${LOCATION}.p.rep.googleapis.com`) if you use private REP.
+
+> **Why this is the top failure mode.** Many users register only the base hostname. The 403 surfaces later when an SDK upgrade, a regional client configuration change, an mTLS opt-in, or a backend rollout causes the agent to call a different host. A failure that reads as "worked yesterday, fails today, no configuration changed" is almost always this.
+
+---
+
+## Diagnose a 403 from an agent
+
+Walk the following checks in order. Most failures resolve at Step 2 or Step 4.
+
+### Diagnostic flow at a glance
+
+```mermaid
+flowchart TD
+    start(["403 reported by agent"]) --> s1["Step 1: Confirm 403 in<br/>ReasoningEngine logs"]
+    s1 --> s2["Step 2: Read failing :authority<br/>hostname from gateway log"]
+    s2 --> s3{"IAP audit entry<br/>for this call?"}
+    s3 -- "No" --> s3b["Step 3b: Inspect gateway<br/>proxy load-balancer logs"]
+    s3 -- "Yes" --> s3a["Step 3: Read IAP decision,<br/>principal, enforcement mode"]
+    s3a --> s4{"Hostname registered<br/>in Agent Registry?"}
+    s3b --> s4
+    s4 -- "No" --> fix1["Register the exact hostname<br/>(and all permutations)"]
+    s4 -- "Yes" --> s5{"IAM binding with<br/>roles/iap.egressor on resource?"}
+    s5 -- "No" --> fix2["Add the IAM binding"]
+    s5 -- "Yes" --> s6{"authz_policy targets<br/>this gateway?"}
+    s6 -- "No" --> fix3["Create authz_policy<br/>targeting the gateway"]
+    s6 -- "Yes" --> s7{"Agent identity has<br/>baseline roles?"}
+    s7 -- "No" --> fix4["Grant aiplatform.user,<br/>agentregistry.viewer, browser,<br/>telemetry roles"]
+    s7 -- "Yes" --> s7b{"PAB blocks the<br/>destination resource?"}
+    s7b -- "Yes" --> fix5["Widen PAB or remove<br/>the binding"]
+    s7b -- "No" --> s8["Step 8: Switch from PrincipalSet<br/>to direct Principal binding"]
+```
+
+### Step 1 — Confirm the 403 in agent logs
+
+Check the Reasoning Engine logs for the failing call:
+
+```
+resource.type="aiplatform.googleapis.com/ReasoningEngine"
+resource.labels.location="$LOCATION"
+resource.labels.reasoning_engine_id="$AGENT_ID"
+textPayload:"403"
+```
+
+Look for the canonical `Egress request is not authorized` payload. If the 403 carries different text, the failure is probably not an Agent Gateway issue — the destination service might be rejecting the call directly.
+
+### Step 2 — Identify the failing hostname in gateway logs
+
+```
+resource.type="networkservices.googleapis.com/Gateway"
+resource.labels.location="$REGION"
+resource.labels.gateway_name="$AGENT_GATEWAY_NAME"
+```
+
+Read the `:authority` (or host) header on the failing request. Record the exact value. The rest of the diagnosis pivots on this hostname — comparing it to what is registered explains most failures.
+
+### Step 3 — Read the IAP authorization decision
+
+Narrow to the egress permission and exclude MCP base-protocol noise:
+
+```
+protoPayload.serviceName="iap.googleapis.com"
+protoPayload.authorizationInfo.permission="iap.webServiceVersions.egressViaIAP"
+-protoPayload.metadata.mcp_attributes.base_protocol_method="true"
+```
+
+Pull these fields from the matching entry:
+
+- `protoPayload.authorizationInfo[].granted` — `true` or `false`. The bottom-line decision.
+- `protoPayload.authenticationInfo.principalSubject` — the SPIFFE or `principal://...` URI of the caller. Compare this string verbatim to the binding's principal.
+- `protoPayload.authorizationInfo[].resource` — the registered resource the call resolved to.
+- `labels."iap.googleapis.com/audited_resource_name"` — if this is `unregisteredResource`, the destination hostname is not in the registry at all (or does not match exactly). Skip ahead to [Step 4](#step-4--verify-hostname-registration).
+- The enforcement mode. Look for metadata such as:
+
+  ```yaml
+  service: iap.googleapis.com
+  failOpen: true
+  timeout: 1s
+  metadata:
+    iamEnforcementMode: "DRY_RUN"
+  ```
+
+  In `DRY_RUN`, denials are logged but not enforced. If your agent fails with a real 403 and IAP is in dry-run, the denial originates elsewhere — either the gateway's underlying egress proxy (next step) or the destination service rejecting the call.
+
+### Step 3b — Inspect gateway proxy logs when no IAP entry exists
+
+A request denied by the gateway's egress proxy never reaches IAP, so no IAP audit entry exists for it. The denial appears in the gateway's load-balancer logs:
+
+```
+jsonPayload.@type="type.googleapis.com/google.cloud.loadbalancing.type.LoadBalancerLogEntry"
+-httpRequest.requestMethod="CONNECT"
+resource.labels.gateway_type="SECURE_WEB_GATEWAY"
+```
+
+Key fields to read: `httpRequest.status` (look for 403), `jsonPayload.authzPolicyInfo.policies.result` (overall AuthZ result), and `httpRequest.requestUrl` (exact destination). The `gateway_type="SECURE_WEB_GATEWAY"` label refers to the proxy implementation. You do not configure it directly, but its denials surface here.
+
+### Step 4 — Verify hostname registration
+
+List Agent Registry entries — pick the right resource type for the destination:
+
+```bash
+gcloud alpha agent-registry endpoints list      --project="$PROJECT_ID" --location="$LOCATION"
+gcloud alpha agent-registry mcp-servers list    --project="$PROJECT_ID" --location="$LOCATION"
+gcloud alpha agent-registry agents list         --project="$PROJECT_ID" --location="$LOCATION"
+```
+
+Search the output for the exact hostname from Step 2. If it is missing, the agent is calling a permutation that was never registered. Register it, and ideally register all five or six permutations at once to prevent the same incident next time.
+
+### Step 5 — Verify IAM bindings on the registered resource
+
+The agent's identity, or a principal set the agent belongs to, needs the `roles/iap.egressor` role on the destination. Bindings live at the registry level (which covers everything) or on a specific resource (fine-grained).
+
+Read the registry-level IAM policy:
+
+```bash
+curl -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
+  -d '{}' \
+  -X POST "https://iap.googleapis.com/v1/projects/${PROJECT_NUMBER}/locations/${LOCATION}/iap_web/agentRegistry:getIamPolicy" \
+  -H "Content-Type: application/json"
+```
+
+Read a per-endpoint IAM policy:
+
+```bash
+curl -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
+  -d '{}' \
+  -X POST "https://iap.googleapis.com/v1/projects/${PROJECT_NUMBER}/locations/${LOCATION}/iap_web/agentRegistry/endpoints/${ENDPOINT_ID}:getIamPolicy" \
+  -H "Content-Type: application/json"
+```
+
+The same call works for the global registry — some resources live there, not regionally. Replace `${LOCATION}` with `global` in the URL and add `{"options": {"requestedPolicyVersion": 3}}` to the body.
+
+In the returned policy, look for a binding that matches *one of*:
+
+- The agent's service account, for example `serviceAccount:my-agent@…iam.gserviceaccount.com`.
+- A principal set the agent belongs to.
+
+…with role `roles/iap.egressor`.
+
+If a binding exists with a `condition`, read the CEL expression carefully. A condition that filters by an attribute the failing agent does not carry silently excludes it.
+
+### Step 6 — Inspect gateway and authz extension wiring
+
+List the authz extensions:
+
+```bash
+gcloud beta service-extensions authz-extensions list \
+  --location="$LOCATION" --project="$PROJECT_ID"
+
+gcloud beta service-extensions authz-extensions describe RESOURCE_NAME \
+  --location="$LOCATION" --project="$PROJECT_ID"
+```
+
+Confirm an `authz_policy` actually targets the gateway resource. Defining the extension is not enough. A policy must attach it to a specific gateway:
+
+```bash
+curl -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
+  "https://networksecurity.googleapis.com/v1alpha1/projects/${PROJECT_ID}/locations/${LOCATION}/authzPolicies"
+```
+
+Look for a policy whose `target.resources[]` includes the gateway's full resource name.
+
+### Step 7 — Verify baseline agent identity roles
+
+The agent identity needs enough permissions to function on the source side. Without these roles, errors look like authorization failures but actually mean the agent cannot read its own runtime configuration:
+
+- `roles/aiplatform.user` (Vertex AI User) — to run the Reasoning Engine.
+- `roles/agentregistry.viewer` — to know what is registered.
+- `roles/logging.logWriter`, `roles/monitoring.metricWriter`, telemetry roles — observability.
+- `roles/browser` — for `resourcemanager.projects.get` during SDK init. Without it, the Reasoning Engine fails startup with `Failed to convert project number to project ID`.
+
+### Step 7b — Check Principal Access Boundary policies
+
+Even with IAM bindings correct, a PAB policy can restrict the destination scope of the principal set. Symptom: bindings look right, the resource is registered, the role is correct, and the call still returns 403.
+
+```bash
+# List org-wide PAB policies
+gcloud iam principal-access-boundary-policies list \
+  --organization="${ORGANIZATION_ID}" --location=global
+
+# Find what is bound to the agent's principal set
+gcloud iam policy-bindings search-target-policy-bindings \
+  --project="${PROJECT_ID}" --target="${PRINCIPAL_SET}"
+```
+
+If a PAB binding exists for the principal set, inspect its `details.rules[].resources[]`. The destination must be in scope, otherwise the PAB silently denies.
+
+### Step 8 — PrincipalSet versus Principal bindings
+
+If permissions appear intermittent — the call passes some of the time, or works for one agent but fails for an identical sibling — suspect the **PrincipalSet** binding. Move to a 1:1 **Principal** binding (bind the specific service account directly) to verify. PrincipalSet propagation can be eventually consistent. Attribute-based set membership requires the failing agent's principal to actually carry the matching attributes.
+
+The diagnostic test: add a temporary direct `principal://` binding for the failing agent only on the affected resource. If the failing agent starts working, you have isolated the cause to set membership. The durable fix is to either correct the agent's identity attributes (so it legitimately matches the set), or to switch to a small fixed roster of `principal://` bindings.
+
+---
+
+## Common issues
+
+The following recurring failure modes are indexed by symptom. When the symptom matches one of these, jump straight here instead of walking the full diagnostic flow.
+
+### ReasoningEngine startup fails with "Failed to convert project number to project ID"
+
+**Symptom.** Log name `aiplatform.googleapis.com/reasoning_engine_stderr`. Error text: `google.api_core.exceptions.Unknown: None` or `Failed to convert project number to project ID.`. The error appears during Reasoning Engine startup, before any user code runs.
+
+**Cause.** The Reasoning Engine's system identity (the principal set it runs under) lacks `resourcemanager.projects.get`. The Vertex AI SDK needs that permission to resolve the project name during init.
+
+**Fix.** Grant `roles/browser` to the Reasoning Engine principal set:
+
+```bash
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member="principalSet://agents.global.org-${ORG_ID}.system.id.goog/attribute.platformContainer/aiplatform/projects/${PROJECT_NUMBER}" \
+  --role="roles/browser"
+```
+
+### "Assembly Service failed to initialize"
+
+**Symptom.** `[1099] ERROR: Assembly Service failed to initialize.` in `reasoning_engine_stderr`.
+
+**Cause.** Generic init failure. Usually a downstream symptom of either the project-number resolution issue above or a runtime error in the agent's `set_up()` method.
+
+**Investigation.** Pull all `severity=ERROR` from `reasoning_engine_stderr` around the same timestamp. The actual root cause appears in the same window.
+
+### Only one Reasoning Engine per project can bond to an Agent Gateway (preview limit)
+
+**Symptom.** Updating a Reasoning Engine to use an Agent Gateway fails with `Internal error encountered` or `The specified parameters are invalid.`
+
+**Cause.** During the private preview, a project supports only one active Reasoning Engine ↔ Agent Gateway bonding. A second bonding attempt fails.
+
+**Fix.** Either delete the existing bonded Reasoning Engine or Agent Gateway, or reuse the existing Agent Gateway for any new Reasoning Engines.
+
+### 403 "Egress request is not authorized" with no authz_policy on the gateway
+
+**Symptom.** Audit logs show `GatekeeperAuthorizer.AuthorizeUser` returning `Permission Denied` for `iap.webServiceVersions.egressViaIAP`.
+
+**Cause.** The IAP authz extension exists, but no `authz_policy` attaches it to the specific Agent Gateway. The extension is configured but the policy that targets the gateway resource is missing.
+
+**Fix.** Verify there is an `authz_policy` in the consumer project that targets the specific `agentGateway` resource. Check with:
+
+```bash
+curl -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
+  "https://networksecurity.googleapis.com/v1alpha1/projects/${PROJECT_ID}/locations/${LOCATION}/authzPolicies"
+```
+
+Look for a policy whose `target.resources[]` includes the gateway's full resource name.
+
+### IAP ENFORCE mode blocks Agent Engine startup
+
+**Symptom.** Agent Engine instances fail to deploy or start, with 403s in startup logs.
+
+**Cause.** With IAP in `ENFORCE` mode on the Agent Gateway, all egress is denied by default — including the bootstrap calls the agent runtime makes to `cloudresourcemanager`, `aiplatform`, `logging`, `monitoring`, and others. If those endpoints are not registered and the agent identity lacks `roles/iap.egressor` on them, startup never completes.
+
+**Fix.** Make sure the bootstrap service set is registered in the Agent Registry (see [Required Google Cloud APIs to register](#required-google-cloud-apis-to-register)) and that the agent identity has `roles/iap.egressor` on those resources. While debugging, flipping IAP to `DRY_RUN` lets you observe the failing destinations without blocking startup.
+
+### Self-signed or Private CA destinations fail to connect
+
+**Symptom.** The agent fails to connect to internal MCP servers or tools that present self-signed or Private CA-issued certificates.
+
+**Cause.** In private preview and early Agent Gateway versions, the gateway's egress proxy cannot validate self-signed cert chains.
+
+**Mitigation.** Use publicly-trusted CA certificates for internal MCP servers, or wait for the platform enhancement that adds Private CA trust-anchor support.
+
+### VPC Service Controls compatibility
+
+**Symptom.** Agent Gateway traffic is denied by VPC Service Controls perimeters, or you cannot include Agent Gateway in a perimeter.
+
+**Cause.** Agent Gateway does not natively support VPC Service Controls in some deployment modes.
+
+**Mitigation.** Use custom Organization Policy constraints to restrict which gateways agents are allowed to use. This stops agents from bypassing the platform:
+
+- `custom.requireEgressAgentGatewaysForAgentEngine` (Agent Engine).
+- Equivalent constraints for Gemini Enterprise.
+
+These constraints enforce "agents must use approved Agent Gateways" at the Organization Policy layer, instead of relying on VPC Service Controls.
+
+### Principal Access Boundary policies override IAM Allow
+
+**Symptom.** The agent identity has the right roles bound (`roles/iap.egressor`, `roles/aiplatform.user`, and others), the resource is registered correctly, and calls still return 403.
+
+**Cause.** A Principal Access Boundary policy is restricting the scope of resources the principal can access. **PAB policies take precedence over IAM Allow policies.** Even a correct binding does nothing if a PAB blocks the target resource.
+
+**Investigation.**
+
+```bash
+# List org-wide PAB policies
+gcloud iam principal-access-boundary-policies list \
+  --organization="${ORGANIZATION_ID}" --location=global
+
+# Find what is bound to a specific principal set or agent identity
+gcloud iam policy-bindings search-target-policy-bindings \
+  --project="${PROJECT_ID}" --target="${PRINCIPAL_SET}"
+```
+
+**Fix.** Either widen the PAB to include the destination resource, or remove the PAB binding from the agent's principal set if it should not apply.
+
+### Gateway proxy denies the request before IAP runs
+
+**Symptom.** Requests fail with no IAP audit log entry. IAP never saw the call.
+
+**Cause.** The gateway's underlying egress proxy enforces a deny-by-default posture *before* IAP authorization runs. When the proxy denies a call, IAP does not get a chance to evaluate it, so no IAP audit log entry appears.
+
+**Investigation.** Pull the gateway proxy load-balancer logs (filter under [Log queries](#log-queries) — "Gateway proxy load-balancer logs"). Key fields: `httpRequest.status`, `jsonPayload.authzPolicyInfo.policies.result`, `httpRequest.requestUrl`.
+
+**Fix.** This is almost always upstream — usually a missing or misconfigured Agent Registry entry, an `authz_policy` that does not target the gateway, or a recent platform-side change. Walk Step 4 (registry verification) and Step 6 (authz wiring) of the diagnostic flow. The proxy's policy is Google-managed and derived from your registry and policy state; you do not edit it directly.
+
+---
+
+## Reference
+
+### Log queries
+
+Copy these into Cloud Logging.
+
+**Agent (ReasoningEngine) logs — find the 403:**
+
+```
+resource.type="aiplatform.googleapis.com/ReasoningEngine"
+resource.labels.location="$LOCATION"
+resource.labels.reasoning_engine_id="$AGENT_ID"
+textPayload:"403"
+```
+
+**Agent stderr — startup failures:**
+
+```
+resource.type="aiplatform.googleapis.com/ReasoningEngine"
+logName:"reasoning_engine_stderr"
+severity>=ERROR
+```
+
+**Gateway logs — find the failing hostname:**
+
+```
+resource.type="networkservices.googleapis.com/Gateway"
+resource.labels.location="$REGION"
+resource.labels.gateway_name="$AGENT_GATEWAY_NAME"
+```
+
+**IAP audit logs — decision, principal, enforcement mode:**
+
+```
+protoPayload.serviceName="iap.googleapis.com"
+protoPayload.authorizationInfo.permission="iap.webServiceVersions.egressViaIAP"
+-protoPayload.metadata.mcp_attributes.base_protocol_method="true"
+```
+
+**IAP audit logs — narrowed to a specific principal:**
+
+Add this clause to scope to one agent identity:
+
+```
+protoPayload.authenticationInfo.principalSubject:"<PRINCIPAL_OR_SA_FRAGMENT>"
+```
+
+**IAM activity — recent SetIamPolicy changes:**
+
+```
+logName="projects/$PROJECT_ID/logs/cloudaudit.googleapis.com%2Factivity"
+protoPayload.methodName="SetIamPolicy"
+```
+
+**Gateway proxy load-balancer logs — denials before IAP:**
+
+When the gateway's egress proxy denies a request before IAP runs, the entry does not appear in IAP audit logs — only in the proxy's load-balancer log. The `SECURE_WEB_GATEWAY` label refers to the proxy implementation under the hood.
+
+```
+jsonPayload.@type="type.googleapis.com/google.cloud.loadbalancing.type.LoadBalancerLogEntry"
+-httpRequest.requestMethod="CONNECT"
+resource.labels.gateway_type="SECURE_WEB_GATEWAY"
+```
+
+### gcloud and curl commands
+
+**Inspect the registry:**
+
+```bash
+gcloud alpha agent-registry endpoints list     --project="$PROJECT_ID" --location="$LOCATION"
+gcloud alpha agent-registry mcp-servers list   --project="$PROJECT_ID" --location="$LOCATION"
+gcloud alpha agent-registry agents list        --project="$PROJECT_ID" --location="$LOCATION"
+
+gcloud alpha agent-registry endpoints describe  ENDPOINT_ID  --project="$PROJECT_ID" --location="$LOCATION"
+gcloud alpha agent-registry mcp-servers describe MCP_NAME    --project="$PROJECT_ID" --location="$LOCATION"
+```
+
+**Inspect IAM on registry resources (through the IAP API):**
+
+```bash
+# Registry-wide (regional)
+curl -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
+  -d '{}' \
+  -X POST "https://iap.googleapis.com/v1/projects/${PROJECT_NUMBER}/locations/${LOCATION}/iap_web/agentRegistry:getIamPolicy" \
+  -H "Content-Type: application/json"
+
+# Registry-wide (global)
+curl -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
+  -d '{"options": {"requestedPolicyVersion": 3}}' \
+  -X POST "https://iap.googleapis.com/v1/projects/${PROJECT_NUMBER}/locations/global/iap_web/agentRegistry:getIamPolicy" \
+  -H "Content-Type: application/json"
+
+# Specific endpoint
+curl -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
+  -d '{}' \
+  -X POST "https://iap.googleapis.com/v1/projects/${PROJECT_NUMBER}/locations/${LOCATION}/iap_web/agentRegistry/endpoints/${ENDPOINT_ID}:getIamPolicy" \
+  -H "Content-Type: application/json"
+
+# Specific MCP server
+curl -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
+  -d '{}' \
+  -X POST "https://iap.googleapis.com/v1/projects/${PROJECT_NUMBER}/locations/${LOCATION}/iap_web/agentRegistry/mcpServers/${MCP_SERVER_NAME}:getIamPolicy" \
+  -H "Content-Type: application/json"
+```
+
+**Inspect gateway and authz wiring:**
+
+```bash
+# Authz extensions (the IAP service-extension callouts)
+gcloud beta service-extensions authz-extensions list      --location="$LOCATION" --project="$PROJECT_ID"
+gcloud beta service-extensions authz-extensions describe RESOURCE_NAME --location="$LOCATION" --project="$PROJECT_ID"
+
+# Authz policies (must target the gateway to take effect)
+curl -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
+  "https://networksecurity.googleapis.com/v1alpha1/projects/${PROJECT_ID}/locations/${LOCATION}/authzPolicies"
+
+# Agent gateways
+curl -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
+  "https://networkservices.googleapis.com/v1alpha1/projects/${PROJECT_ID}/locations/${LOCATION}/agentGateways"
+```
+
+**Inspect Principal Access Boundary policies:**
+
+```bash
+gcloud iam principal-access-boundary-policies list \
+  --organization="${ORGANIZATION_ID}" --location=global
+
+gcloud iam principal-access-boundary-policies search-policy-bindings "${PAB_POLICY_ID}" \
+  --organization="${ORGANIZATION_ID}" --location=global
+
+gcloud iam policy-bindings search-target-policy-bindings \
+  --project="${PROJECT_ID}" --target="${PRINCIPAL_SET}"
+```
+
+### The IAP role you need
+
+The display name "IAP-secured Egressor" maps to **`roles/iap.egressor`**. That is the role for Agent Gateway egress.
+
+Several other IAP roles exist with names that look similar but are unrelated to agent egress:
+
+| Role ID | Purpose | Use for Agent Gateway? |
+|---|---|---|
+| `roles/iap.egressor` | Agent egress through Agent Gateway. | **Yes — this one.** |
+| `roles/iap.tunnelResourceAccessor` | TCP and SSH tunneling through IAP to a VM. | No. |
+| `roles/iap.httpsResourceAccessor` | Access to IAP-protected web apps (ingress). | No. |
+| `roles/iap.tunnelDestGroupUser` | Member of an IAP tunnel destination group. | No. |
+
+The IAP authz check for Agent Gateway looks for the permission `iap.webServiceVersions.egressViaIAP`, which only `roles/iap.egressor` grants on this surface. Substituting any of the other roles does not work, even though the names sound similar.
+
+Bind the role at the right scope:
+
+- **Registry-wide.** Covers every agent, MCP server, and endpoint in the registry. This is the easiest scope to manage and what most teams use.
+- **Per-resource.** Narrower. Useful when different agents need different access. Important caveat: a per-resource binding *replaces* the registry-wide binding for that resource — it does not merge. If you put a per-resource binding on `mcp-customer-data` listing only Agent A, Agent B loses access to `mcp-customer-data` even when Agent B has the registry-wide binding.
+
+### Required Google Cloud APIs to register
+
+For a typical agent doing inference plus observability, the following service IDs need endpoints registered (each with all hostname permutations from [Hostname permutations are the most common cause](#hostname-permutations-are-the-most-common-cause)):
+
+- `aiplatform`
+- `cloudresourcemanager`
+- `discoveryengine`
+- `logging`
+- `monitoring`
+- `oauth2`
+- `telemetry`
+- `trace`
+- `agentregistry`
+- `iap`
+- `modelarmor`
+- `iamcredentials`
+
+Missing any of these is the most common "agent works in dev, fails in prod" cause. If you registered `aiplatform` base-only, the others probably are too — audit them at the same time.
+
+### Glossary
+
+**Agent Gateway.** The egress proxy that sits in front of agents (typically Vertex AI Reasoning Engines). It intercepts every outbound call and applies the registered policies before allowing or denying the request. Resource type in logs: `networkservices.googleapis.com/Gateway`.
+
+**Agent Registry.** The catalogue of destinations an agent is permitted to reach. Three resource types:
+
+- **Endpoints** — Google Cloud APIs and external HTTPS services.
+- **MCP servers** — registered MCP servers the agent can call.
+- **Agents** — other agents this agent can call.
+
+**Agent identity.** The runtime identity the agent calls under. May be a service account or a SPIFFE-style `principal://...` URI under the trust domain `agents.global.org-<ORG_ID>.system.id.goog`.
+
+**PrincipalSet.** A collection of identities expressed as a `principalSet://...` URI keyed off attributes (for example `attribute.platformContainer/aiplatform/projects/<PROJECT_NUMBER>`). Useful when you want to grant a role to "all agents matching X" rather than enumerate each one. Membership is computed from attributes; if an agent's identity attributes do not match, it is not in the set.
+
+**Service extension (delegated authorization).** A callout from the gateway to an external authorizer (typically IAP) that decides whether to allow the request. Attached to the gateway through an `authz_policy`.
+
+**`authz_policy`.** The resource that wires a service extension to a specific gateway. Without an `authz_policy` targeting the gateway, the extension does nothing.
+
+**Identity-Aware Proxy (IAP).** Used here as the delegated authorizer for the Agent Gateway. The relevant role is `roles/iap.egressor`; the relevant permission is `iap.webServiceVersions.egressViaIAP`.
+
+**Principal Access Boundary (PAB).** A constraint policy on a principal set that restricts which resources its members can access. **Overrides IAM Allow.**
+
+**Secure Web Proxy.** The Google-managed proxy implementation that Agent Gateway is built on. It provides the egress-proxy capabilities (deny-by-default enforcement, traffic interception). You do not configure it directly — its rules derive from your Agent Registry entries and authz policies. Denials at this layer (before IAP runs) do not appear in IAP audit logs but do appear in load-balancer logs with `resource.labels.gateway_type="SECURE_WEB_GATEWAY"`.
+
+**Regional Endpoint Proxy (REP).** A regional hostname form such as `aiplatform.us-central1.rep.googleapis.com` (public) or `aiplatform.us-central1.p.rep.googleapis.com` (private/PSC). Distinct from the locational form (`us-central1-aiplatform.googleapis.com`); both forms exist and the gateway treats them as separate hostnames.
+
+**Default-deny.** The platform's posture: every layer denies unless explicitly told to allow. A missing entry at any layer returns the same generic 403, so triage is about *which layer* denied, not whether one did.

--- a/demos/agent-gateway/terraform/main.tf
+++ b/demos/agent-gateway/terraform/main.tf
@@ -74,6 +74,16 @@ module "foundation" {
   logging_data_access  = var.logging_data_access
 }
 
+# Phase 1.5: Observability - Log Analytics on _Default + authorization
+# debugging dashboard.
+module "observability" {
+  source = "./modules/observability"
+
+  project_id = var.project_id
+
+  depends_on = [module.foundation]
+}
+
 # Phase 2: Networking - VPC, Subnets, NAT, Static IPs, private DNS zones
 module "networking" {
   source = "./modules/networking"

--- a/demos/agent-gateway/terraform/modules/foundation/variables.tf
+++ b/demos/agent-gateway/terraform/modules/foundation/variables.tf
@@ -103,14 +103,14 @@ variable "enable_psc_interface" {
 }
 
 variable "logging_data_access" {
-  description = "Data access audit log configuration. Map of service name to a map of log type (ADMIN_READ|DATA_READ|DATA_WRITE) to optional exempted_members."
+  description = "Data access audit log configuration. Map of service name to a map of log type (ADMIN_READ|DATA_READ|DATA_WRITE) to optional exempted_members. Use the special 'allServices' key to apply project-wide across every API."
   type = map(object({
     ADMIN_READ = optional(object({ exempted_members = optional(list(string), []) }))
     DATA_READ  = optional(object({ exempted_members = optional(list(string), []) }))
     DATA_WRITE = optional(object({ exempted_members = optional(list(string), []) }))
   }))
   default = {
-    "iap.googleapis.com" = {
+    "allServices" = {
       ADMIN_READ = {}
       DATA_READ  = {}
       DATA_WRITE = {}

--- a/demos/agent-gateway/terraform/modules/observability/authorization-debugging.json
+++ b/demos/agent-gateway/terraform/modules/observability/authorization-debugging.json
@@ -194,7 +194,6 @@
       },
       {
         "yPos": 54,
-        "xPos": 0,
         "height": 16,
         "width": 48,
         "widget": {

--- a/demos/agent-gateway/terraform/modules/observability/authorization-debugging.json
+++ b/demos/agent-gateway/terraform/modules/observability/authorization-debugging.json
@@ -1,0 +1,225 @@
+{
+  "displayName": "Agent Platform: Authorization Debugging",
+  "dashboardFilters": [
+    {
+      "filterType": "VALUE_ONLY",
+      "labelKey": "",
+      "templateVariable": "agent_identity",
+      "timeSeriesQuery": {
+        "opsAnalyticsQuery": {
+          "savedQueryId": "",
+          "sql": "SELECT REGEXP_EXTRACT(proto_payload.audit_log.authentication_info.principal_subject, r'([^/]+)$') AS reasoning_engine_id FROM `duncanjames-agw-tf.global._Default._AllLogs` WHERE proto_payload.audit_log.service_name = 'iap.googleapis.com' AND proto_payload.audit_log.authentication_info.principal_subject LIKE '%/reasoningEngines/%' GROUP BY reasoning_engine_id"
+        },
+        "outputFullDuration": false,
+        "unitOverride": ""
+      },
+      "valueType": "STRING"
+    },
+    {
+      "filterType": "VALUE_ONLY",
+      "labelKey": "",
+      "templateVariable": "gateway",
+      "timeSeriesQuery": {
+        "opsAnalyticsQuery": {
+          "savedQueryId": "",
+          "sql": "SELECT REGEXP_EXTRACT(JSON_VALUE(resource.labels.gateway_name), r'([^/]+)$') AS gateway_name FROM `duncanjames-agw-tf.global._Default._AllLogs` WHERE resource.type = 'networkservices.googleapis.com/Gateway' AND JSON_VALUE(resource.labels.gateway_name) IS NOT NULL GROUP BY gateway_name"
+        },
+        "outputFullDuration": false,
+        "unitOverride": ""
+      },
+      "valueType": "STRING"
+    },
+    {
+      "filterType": "VALUE_ONLY",
+      "labelKey": "",
+      "templateVariable": "region",
+      "timeSeriesQuery": {
+        "opsAnalyticsQuery": {
+          "savedQueryId": "",
+          "sql": "SELECT JSON_VALUE(resource.labels.location) AS location FROM `duncanjames-agw-tf.global._Default._AllLogs` WHERE resource.type = 'networkservices.googleapis.com/Gateway' AND JSON_VALUE(resource.labels.location) IS NOT NULL GROUP BY location"
+        },
+        "outputFullDuration": false,
+        "unitOverride": ""
+      },
+      "valueType": "STRING"
+    },
+    {
+      "filterType": "VALUE_ONLY",
+      "labelKey": "",
+      "templateVariable": "destination",
+      "timeSeriesQuery": {
+        "opsAnalyticsQuery": {
+          "savedQueryId": "",
+          "sql": "SELECT JSON_VALUE(json_payload.tlsSniHostname) AS host FROM `duncanjames-agw-tf.global._Default._AllLogs` WHERE resource.type = 'networkservices.googleapis.com/Gateway' AND JSON_VALUE(json_payload.tlsSniHostname) IS NOT NULL GROUP BY host"
+        },
+        "outputFullDuration": false,
+        "unitOverride": ""
+      },
+      "valueType": "STRING"
+    }
+  ],
+  "description": "",
+  "labels": {},
+  "mosaicLayout": {
+    "columns": 48,
+    "tiles": [
+      {
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Agent ➔ Endpoint (403 Denials)",
+          "id": "",
+          "timeSeriesTable": {
+            "columnSettings": [],
+            "dataSets": [
+              {
+                "tableTemplate": "",
+                "timeSeriesQuery": {
+                  "opsAnalyticsQuery": {
+                    "savedQueryId": "",
+                    "sql": "WITH iap_logs AS ( SELECT proto_payload.audit_log.request_metadata.request_attributes.host AS host, REGEXP_EXTRACT(proto_payload.audit_log.authentication_info.principal_subject, r'([^/]+)$') AS reasoning_engine_id, REGEXP_EXTRACT(auth.resource, r'agentRegistry/((?:endpoints|mcpServers|agents)/[^/]+)') AS short_resource, IFNULL(auth.granted, FALSE) AS iap_is_authorized, JSON_VALUE(proto_payload.audit_log.metadata, '$.dryRun') = 'true' AS iap_dry_run, COUNT(*) AS iap_log_count FROM `duncanjames-agw-tf.global._Default._AllLogs`, UNNEST(proto_payload.audit_log.authorization_info) AS auth WHERE proto_payload.audit_log.service_name = \"iap.googleapis.com\" AND proto_payload.audit_log.request_metadata.request_attributes.host IS NOT NULL GROUP BY 1, 2, 3, 4, 5 ), gw_logs AS ( SELECT JSON_VALUE(json_payload.tlsSniHostname) AS host, REGEXP_EXTRACT(JSON_VALUE(resource.labels.gateway_name), r'([^/]+)$') AS gateway_name, JSON_VALUE(resource.labels.location) AS location, REGEXP_EXTRACT(JSON_VALUE(json_payload.agentGatewayInfo.agentRegistryResource), r'((?:endpoints|mcpServers|agents)/[^/]+)') AS short_resource, JSON_VALUE(json_payload.authzPolicyInfo.result) = 'ALLOWED' AS gw_is_authorized, COUNT(*) AS gw_log_count FROM `duncanjames-agw-tf.global._Default._AllLogs` WHERE resource.type = \"networkservices.googleapis.com/Gateway\" AND JSON_VALUE(json_payload.tlsSniHostname) IS NOT NULL AND http_request.request_method != 'CONNECT' GROUP BY 1, 2, 3, 4, 5 ), joined_logs AS ( SELECT COALESCE(i.host, g.host) AS host, i.reasoning_engine_id, g.gateway_name, g.location, COALESCE(i.short_resource, g.short_resource) AS short_resource, i.iap_is_authorized, g.gw_is_authorized, i.iap_dry_run, IFNULL(i.iap_log_count, 0) AS iap_log_count, IFNULL(g.gw_log_count, 0) AS gw_log_count FROM iap_logs i FULL OUTER JOIN gw_logs g ON i.host = g.host AND IFNULL(i.short_resource, '') = IFNULL(g.short_resource, '') ) SELECT reasoning_engine_id AS Agent, short_resource AS Endpoint, host, gw_is_authorized, iap_is_authorized, (iap_log_count + gw_log_count) AS Denied_Count FROM joined_logs WHERE short_resource LIKE 'endpoints/%' AND (iap_is_authorized = FALSE OR gw_is_authorized = FALSE) AND IF(@agent_identity = \"*\", TRUE, reasoning_engine_id = @agent_identity) AND IF(@gateway = \"*\", TRUE, gateway_name = @gateway) AND IF(@region = \"*\", TRUE, location = @region) AND IF(@destination = \"*\", TRUE, host = @destination) ORDER BY Denied_Count DESC"
+                  },
+                  "outputFullDuration": false,
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "displayColumnType": false,
+            "metricVisualization": "NUMBER"
+          }
+        }
+      },
+      {
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Agent ➔ MCP Server (403 Denials)",
+          "id": "",
+          "timeSeriesTable": {
+            "columnSettings": [],
+            "dataSets": [
+              {
+                "tableTemplate": "",
+                "timeSeriesQuery": {
+                  "opsAnalyticsQuery": {
+                    "savedQueryId": "",
+                    "sql": "WITH iap_logs AS ( SELECT proto_payload.audit_log.request_metadata.request_attributes.host AS host, REGEXP_EXTRACT(proto_payload.audit_log.authentication_info.principal_subject, r'([^/]+)$') AS reasoning_engine_id, REGEXP_EXTRACT(auth.resource, r'agentRegistry/((?:endpoints|mcpServers|agents)/[^/]+)') AS short_resource, IFNULL(auth.granted, FALSE) AS iap_is_authorized, JSON_VALUE(proto_payload.audit_log.metadata, '$.dryRun') = 'true' AS iap_dry_run, COUNT(*) AS iap_log_count FROM `duncanjames-agw-tf.global._Default._AllLogs`, UNNEST(proto_payload.audit_log.authorization_info) AS auth WHERE proto_payload.audit_log.service_name = \"iap.googleapis.com\" AND proto_payload.audit_log.request_metadata.request_attributes.host IS NOT NULL GROUP BY 1, 2, 3, 4, 5 ), gw_logs AS ( SELECT JSON_VALUE(json_payload.tlsSniHostname) AS host, REGEXP_EXTRACT(JSON_VALUE(resource.labels.gateway_name), r'([^/]+)$') AS gateway_name, JSON_VALUE(resource.labels.location) AS location, REGEXP_EXTRACT(JSON_VALUE(json_payload.agentGatewayInfo.agentRegistryResource), r'((?:endpoints|mcpServers|agents)/[^/]+)') AS short_resource, JSON_VALUE(json_payload.authzPolicyInfo.result) = 'ALLOWED' AS gw_is_authorized, COUNT(*) AS gw_log_count FROM `duncanjames-agw-tf.global._Default._AllLogs` WHERE resource.type = \"networkservices.googleapis.com/Gateway\" AND JSON_VALUE(json_payload.tlsSniHostname) IS NOT NULL AND http_request.request_method != 'CONNECT' GROUP BY 1, 2, 3, 4, 5 ), joined_logs AS ( SELECT COALESCE(i.host, g.host) AS host, i.reasoning_engine_id, g.gateway_name, g.location, COALESCE(i.short_resource, g.short_resource) AS short_resource, i.iap_is_authorized, g.gw_is_authorized, i.iap_dry_run, IFNULL(i.iap_log_count, 0) AS iap_log_count, IFNULL(g.gw_log_count, 0) AS gw_log_count FROM iap_logs i FULL OUTER JOIN gw_logs g ON i.host = g.host AND IFNULL(i.short_resource, '') = IFNULL(g.short_resource, '') ) SELECT reasoning_engine_id AS Agent, short_resource AS MCP_Server, host, gw_is_authorized, iap_is_authorized, (iap_log_count + gw_log_count) AS Denied_Count FROM joined_logs WHERE short_resource LIKE 'mcpServers/%' AND (iap_is_authorized = FALSE OR gw_is_authorized = FALSE) AND IF(@agent_identity = \"*\", TRUE, reasoning_engine_id = @agent_identity) AND IF(@gateway = \"*\", TRUE, gateway_name = @gateway) AND IF(@region = \"*\", TRUE, location = @region) AND IF(@destination = \"*\", TRUE, host = @destination) ORDER BY Denied_Count DESC"
+                  },
+                  "outputFullDuration": false,
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "displayColumnType": false,
+            "metricVisualization": "NUMBER"
+          }
+        }
+      },
+      {
+        "yPos": 16,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Agent ➔ Agent (403 Denials)",
+          "id": "",
+          "timeSeriesTable": {
+            "columnSettings": [],
+            "dataSets": [
+              {
+                "tableTemplate": "",
+                "timeSeriesQuery": {
+                  "opsAnalyticsQuery": {
+                    "savedQueryId": "",
+                    "sql": "WITH iap_logs AS ( SELECT proto_payload.audit_log.request_metadata.request_attributes.host AS host, REGEXP_EXTRACT(proto_payload.audit_log.authentication_info.principal_subject, r'([^/]+)$') AS reasoning_engine_id, REGEXP_EXTRACT(auth.resource, r'agentRegistry/((?:endpoints|mcpServers|agents)/[^/]+)') AS short_resource, IFNULL(auth.granted, FALSE) AS iap_is_authorized, JSON_VALUE(proto_payload.audit_log.metadata, '$.dryRun') = 'true' AS iap_dry_run, COUNT(*) AS iap_log_count FROM `duncanjames-agw-tf.global._Default._AllLogs`, UNNEST(proto_payload.audit_log.authorization_info) AS auth WHERE proto_payload.audit_log.service_name = \"iap.googleapis.com\" AND proto_payload.audit_log.request_metadata.request_attributes.host IS NOT NULL GROUP BY 1, 2, 3, 4, 5 ), gw_logs AS ( SELECT JSON_VALUE(json_payload.tlsSniHostname) AS host, REGEXP_EXTRACT(JSON_VALUE(resource.labels.gateway_name), r'([^/]+)$') AS gateway_name, JSON_VALUE(resource.labels.location) AS location, REGEXP_EXTRACT(JSON_VALUE(json_payload.agentGatewayInfo.agentRegistryResource), r'((?:endpoints|mcpServers|agents)/[^/]+)') AS short_resource, JSON_VALUE(json_payload.authzPolicyInfo.result) = 'ALLOWED' AS gw_is_authorized, COUNT(*) AS gw_log_count FROM `duncanjames-agw-tf.global._Default._AllLogs` WHERE resource.type = \"networkservices.googleapis.com/Gateway\" AND JSON_VALUE(json_payload.tlsSniHostname) IS NOT NULL AND http_request.request_method != 'CONNECT' GROUP BY 1, 2, 3, 4, 5 ), joined_logs AS ( SELECT COALESCE(i.host, g.host) AS host, i.reasoning_engine_id, g.gateway_name, g.location, COALESCE(i.short_resource, g.short_resource) AS short_resource, i.iap_is_authorized, g.gw_is_authorized, i.iap_dry_run, IFNULL(i.iap_log_count, 0) AS iap_log_count, IFNULL(g.gw_log_count, 0) AS gw_log_count FROM iap_logs i FULL OUTER JOIN gw_logs g ON i.host = g.host AND IFNULL(i.short_resource, '') = IFNULL(g.short_resource, '') ) SELECT reasoning_engine_id AS Agent, short_resource AS Target_Agent, host, gw_is_authorized, iap_is_authorized, (iap_log_count + gw_log_count) AS Denied_Count FROM joined_logs WHERE short_resource LIKE 'agents/%' AND (iap_is_authorized = FALSE OR gw_is_authorized = FALSE) AND IF(@agent_identity = \"*\", TRUE, reasoning_engine_id = @agent_identity) AND IF(@gateway = \"*\", TRUE, gateway_name = @gateway) AND IF(@region = \"*\", TRUE, location = @region) AND IF(@destination = \"*\", TRUE, host = @destination) ORDER BY Denied_Count DESC"
+                  },
+                  "outputFullDuration": false,
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "displayColumnType": false,
+            "metricVisualization": "NUMBER"
+          }
+        }
+      },
+      {
+        "yPos": 16,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Unregistered Outbound Blocks (e.g. GitHub/PyPI)",
+          "id": "",
+          "timeSeriesTable": {
+            "columnSettings": [],
+            "dataSets": [
+              {
+                "tableTemplate": "",
+                "timeSeriesQuery": {
+                  "opsAnalyticsQuery": {
+                    "savedQueryId": "",
+                    "sql": "WITH iap_logs AS ( SELECT proto_payload.audit_log.request_metadata.request_attributes.host AS host, REGEXP_EXTRACT(proto_payload.audit_log.authentication_info.principal_subject, r'([^/]+)$') AS reasoning_engine_id, REGEXP_EXTRACT(auth.resource, r'agentRegistry/((?:endpoints|mcpServers|agents)/[^/]+)') AS short_resource, IFNULL(auth.granted, FALSE) AS iap_is_authorized, JSON_VALUE(proto_payload.audit_log.metadata, '$.dryRun') = 'true' AS iap_dry_run, COUNT(*) AS iap_log_count FROM `duncanjames-agw-tf.global._Default._AllLogs`, UNNEST(proto_payload.audit_log.authorization_info) AS auth WHERE proto_payload.audit_log.service_name = \"iap.googleapis.com\" AND proto_payload.audit_log.request_metadata.request_attributes.host IS NOT NULL GROUP BY 1, 2, 3, 4, 5 ), gw_logs AS ( SELECT JSON_VALUE(json_payload.tlsSniHostname) AS host, REGEXP_EXTRACT(JSON_VALUE(resource.labels.gateway_name), r'([^/]+)$') AS gateway_name, JSON_VALUE(resource.labels.location) AS location, REGEXP_EXTRACT(JSON_VALUE(json_payload.agentGatewayInfo.agentRegistryResource), r'((?:endpoints|mcpServers|agents)/[^/]+)') AS short_resource, JSON_VALUE(json_payload.authzPolicyInfo.result) = 'ALLOWED' AS gw_is_authorized, COUNT(*) AS gw_log_count FROM `duncanjames-agw-tf.global._Default._AllLogs` WHERE resource.type = \"networkservices.googleapis.com/Gateway\" AND JSON_VALUE(json_payload.tlsSniHostname) IS NOT NULL AND http_request.request_method != 'CONNECT' GROUP BY 1, 2, 3, 4, 5 ), joined_logs AS ( SELECT COALESCE(i.host, g.host) AS host, i.reasoning_engine_id, g.gateway_name, g.location, COALESCE(i.short_resource, g.short_resource) AS short_resource, i.iap_is_authorized, g.gw_is_authorized, i.iap_dry_run, IFNULL(i.iap_log_count, 0) AS iap_log_count, IFNULL(g.gw_log_count, 0) AS gw_log_count FROM iap_logs i FULL OUTER JOIN gw_logs g ON i.host = g.host AND IFNULL(i.short_resource, '') = IFNULL(g.short_resource, '') ) SELECT reasoning_engine_id AS Agent, host AS Unregistered_Destination, gw_log_count AS Blocked_Count FROM joined_logs WHERE short_resource IS NULL AND gw_is_authorized = FALSE AND IF(@agent_identity = \"*\", TRUE, reasoning_engine_id = @agent_identity) AND IF(@gateway = \"*\", TRUE, gateway_name = @gateway) AND IF(@region = \"*\", TRUE, location = @region) AND IF(@destination = \"*\", TRUE, host = @destination) ORDER BY Blocked_Count DESC"
+                  },
+                  "outputFullDuration": false,
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "displayColumnType": false,
+            "metricVisualization": "NUMBER"
+          }
+        }
+      },
+      {
+        "yPos": 32,
+        "height": 22,
+        "width": 48,
+        "widget": {
+          "title": "Traffic Overview & IAP Enforcement Mode",
+          "timeSeriesTable": {
+            "columnSettings": [],
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "opsAnalyticsQuery": {
+                    "sql": "WITH iap_logs AS ( SELECT proto_payload.audit_log.request_metadata.request_attributes.host AS host, REGEXP_EXTRACT(proto_payload.audit_log.authentication_info.principal_subject, r'([^/]+)$') AS reasoning_engine_id, REGEXP_EXTRACT(auth.resource, r'agentRegistry/((?:endpoints|mcpServers|agents)/[^/]+)') AS short_resource, IFNULL(auth.granted, FALSE) AS iap_is_authorized, JSON_VALUE(proto_payload.audit_log.metadata, '$.dryRun') = 'true' AS iap_dry_run, COUNT(*) AS iap_log_count FROM `duncanjames-agw-tf.global._Default._AllLogs`, UNNEST(proto_payload.audit_log.authorization_info) AS auth WHERE proto_payload.audit_log.service_name = \"iap.googleapis.com\" AND proto_payload.audit_log.request_metadata.request_attributes.host IS NOT NULL GROUP BY 1, 2, 3, 4, 5 ), gw_logs AS ( SELECT JSON_VALUE(json_payload.tlsSniHostname) AS host, REGEXP_EXTRACT(JSON_VALUE(resource.labels.gateway_name), r'([^/]+)$') AS gateway_name, JSON_VALUE(resource.labels.location) AS location, REGEXP_EXTRACT(JSON_VALUE(json_payload.agentGatewayInfo.agentRegistryResource), r'((?:endpoints|mcpServers|agents)/[^/]+)') AS short_resource, JSON_VALUE(json_payload.authzPolicyInfo.result) = 'ALLOWED' AS gw_is_authorized, COUNT(*) AS gw_log_count FROM `duncanjames-agw-tf.global._Default._AllLogs` WHERE resource.type = \"networkservices.googleapis.com/Gateway\" AND JSON_VALUE(json_payload.tlsSniHostname) IS NOT NULL AND http_request.request_method != 'CONNECT' GROUP BY 1, 2, 3, 4, 5 ), joined_logs AS ( SELECT COALESCE(i.host, g.host) AS host, i.reasoning_engine_id, g.gateway_name, g.location, COALESCE(i.short_resource, g.short_resource) AS short_resource, i.iap_is_authorized, g.gw_is_authorized, i.iap_dry_run, IFNULL(i.iap_log_count, 0) AS iap_log_count, IFNULL(g.gw_log_count, 0) AS gw_log_count FROM iap_logs i FULL OUTER JOIN gw_logs g ON i.host = g.host AND IFNULL(i.short_resource, '') = IFNULL(g.short_resource, '') ) SELECT host, reasoning_engine_id, gateway_name, short_resource, gw_is_authorized, iap_is_authorized, iap_dry_run, iap_log_count, gw_log_count FROM joined_logs WHERE IF(@agent_identity = \"*\", TRUE, reasoning_engine_id = @agent_identity) AND IF(@gateway = \"*\", TRUE, gateway_name = @gateway) AND IF(@region = \"*\", TRUE, location = @region) AND IF(@destination = \"*\", TRUE, host = @destination) ORDER BY (iap_log_count + gw_log_count) DESC"
+                  }
+                }
+              }
+            ],
+            "metricVisualization": "NUMBER"
+          }
+        }
+      },
+      {
+        "yPos": 54,
+        "xPos": 0,
+        "height": 16,
+        "width": 48,
+        "widget": {
+          "title": "Baseline GCP API IAM Denials (Cloud Audit Logs)",
+          "id": "",
+          "timeSeriesTable": {
+            "columnSettings": [],
+            "dataSets": [
+              {
+                "tableTemplate": "",
+                "timeSeriesQuery": {
+                  "opsAnalyticsQuery": {
+                    "savedQueryId": "",
+                    "sql": "SELECT REGEXP_EXTRACT(proto_payload.audit_log.authentication_info.principal_subject, r'([^/]+)$') AS reasoning_engine_id, proto_payload.audit_log.service_name, proto_payload.audit_log.method_name, auth.permission, COUNT(*) AS log_count FROM `duncanjames-agw-tf.global._Default._AllLogs`, UNNEST(proto_payload.audit_log.authorization_info) AS auth WHERE log_name LIKE '%cloudaudit.googleapis.com%' AND IFNULL(auth.granted, false) = false AND proto_payload.audit_log.authentication_info.principal_subject LIKE '%/reasoningEngines/%' AND IF(@agent_identity = \"*\", TRUE, REGEXP_EXTRACT(proto_payload.audit_log.authentication_info.principal_subject, r'([^/]+)$') = @agent_identity) GROUP BY 1, 2, 3, 4 ORDER BY log_count DESC"
+                  },
+                  "outputFullDuration": false,
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "displayColumnType": false,
+            "metricVisualization": "NUMBER"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/demos/agent-gateway/terraform/modules/observability/main.tf
+++ b/demos/agent-gateway/terraform/modules/observability/main.tf
@@ -1,0 +1,51 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+
+/**
+ * Observability Module
+ *
+ * Enables Log Analytics on the auto-created `_Default` log bucket so audit
+ * and platform logs are queryable as `<project>.global._Default._AllLogs`,
+ * and provisions the authorization-debugging Cloud Monitoring dashboard
+ * whose widgets run opsAnalyticsQuery against that view.
+ *
+ * The provider adopts the existing `_Default` bucket — no creation, no
+ * import. `terraform destroy` removes the bucket config from state but
+ * leaves the bucket and its log entries intact (provider semantics for
+ * `_Default` / `_Required` buckets).
+ */
+
+resource "google_logging_project_bucket_config" "default_analytics" {
+  project          = var.project_id
+  location         = "global"
+  bucket_id        = "_Default"
+  enable_analytics = true
+}
+
+# The dashboard JSON ships with `duncanjames-agw-tf` hardcoded in BigQuery-
+# style table refs (`<project>.global._Default._AllLogs`); rewrite it to the
+# caller's project. The on-disk file stays valid JSON so it remains usable
+# for manual import via the GCP console.
+resource "google_monitoring_dashboard" "authorization_debugging" {
+  project = var.project_id
+  dashboard_json = replace(
+    file("${path.module}/authorization-debugging.json"),
+    "duncanjames-agw-tf",
+    var.project_id,
+  )
+
+  depends_on = [google_logging_project_bucket_config.default_analytics]
+}

--- a/demos/agent-gateway/terraform/modules/observability/outputs.tf
+++ b/demos/agent-gateway/terraform/modules/observability/outputs.tf
@@ -1,0 +1,25 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+
+output "dashboard_id" {
+  description = "Resource ID of the authorization-debugging Cloud Monitoring dashboard."
+  value       = google_monitoring_dashboard.authorization_debugging.id
+}
+
+output "log_bucket_id" {
+  description = "Resource ID of the _Default log bucket with Log Analytics enabled."
+  value       = google_logging_project_bucket_config.default_analytics.id
+}

--- a/demos/agent-gateway/terraform/modules/observability/variables.tf
+++ b/demos/agent-gateway/terraform/modules/observability/variables.tf
@@ -1,0 +1,20 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+
+variable "project_id" {
+  description = "GCP project ID hosting the _Default log bucket and the Cloud Monitoring dashboard."
+  type        = string
+}

--- a/demos/agent-gateway/terraform/modules/observability/versions.tf
+++ b/demos/agent-gateway/terraform/modules/observability/versions.tf
@@ -1,0 +1,25 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+
+terraform {
+  required_version = ">= 1.12.2"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 7.16.0"
+    }
+  }
+}

--- a/demos/agent-gateway/terraform/variables.tf
+++ b/demos/agent-gateway/terraform/variables.tf
@@ -503,14 +503,14 @@ variable "agent_registry_custom_services" {
 # ==============================================================================
 
 variable "logging_data_access" {
-  description = "Data access audit log configuration passed to the foundation module. Defaults to ADMIN_READ + DATA_READ + DATA_WRITE for iap.googleapis.com."
+  description = "Data access audit log configuration passed to the foundation module. Defaults to ADMIN_READ + DATA_READ + DATA_WRITE for the special 'allServices' key (project-wide audit logging across every API). Override per-service to scope down or to exempt members."
   type = map(object({
     ADMIN_READ = optional(object({ exempted_members = optional(list(string), []) }))
     DATA_READ  = optional(object({ exempted_members = optional(list(string), []) }))
     DATA_WRITE = optional(object({ exempted_members = optional(list(string), []) }))
   }))
   default = {
-    "iap.googleapis.com" = {
+    "allServices" = {
       ADMIN_READ = {}
       DATA_READ  = {}
       DATA_WRITE = {}


### PR DESCRIPTION
- New observability module deploys the authorization-debugging Cloud Monitoring dashboard, which visualizes 403 denials across agent → endpoint, MCP server, agent → agent, and unregistered outbound traffic.
- Enable Log Analytics on the _Default log bucket so the dashboard's opsAnalyticsQuery widgets can query <project>.global._Default._AllLogs.
- Widen logging_data_access default from iap.googleapis.com to the special 'allServices' key so every API's audit logs flow into _Default and feed the dashboard.

The dashboard JSON moves from the top-level dashboard/ directory into the observability module so the module is self-contained. The hardcoded project ID is rewritten to var.project_id at apply time via replace(), keeping the on-disk file as valid JSON for manual import.

<img width="1451" height="835" alt="image" src="https://github.com/user-attachments/assets/d6591051-8be7-48e0-8b77-be7c5f363a2a" />