### PR TITLE
Agent gateway/fix redaction

### DIFF
--- a/demos/agent-gateway/src/corporate-email/main.py
+++ b/demos/agent-gateway/src/corporate-email/main.py
@@ -16,6 +16,7 @@ import uuid
 from datetime import datetime, timezone
 
 from fastmcp import FastMCP
+from fastmcp.tools.base import ToolResult
 from starlette.applications import Starlette
 from starlette.responses import JSONResponse
 from starlette.routing import Mount, Route
@@ -99,7 +100,7 @@ mcp = FastMCP(name="corporate-email")
 
 
 @mcp.tool()
-def send_email(to: str, subject: str, body: str) -> dict:
+def send_email(to: str, subject: str, body: str) -> ToolResult:
     """Send an email through the corporate email system.
 
     Args:
@@ -108,14 +109,17 @@ def send_email(to: str, subject: str, body: str) -> dict:
         body: Email body content.
 
     Returns:
-        Dictionary with send status, message ID, and timestamp.
+        ToolResult with send status, message ID, and timestamp in structured_content.
     """
+    # content=[] suppresses the duplicate raw-text representation; Model Armor's
+    # CONTENT_AUTHZ only redacts structuredContent, so leaving content[] populated
+    # leaks sensitive fields around the redactor.
     with trace_tool(tracer, "send_email"):
-        return _send(to, subject, body)
+        return ToolResult(content=[], structured_content=_send(to, subject, body))
 
 
 @mcp.tool()
-def read_email(email_id: str | None = None) -> dict:
+def read_email(email_id: str | None = None) -> ToolResult:
     """Read emails from the corporate inbox. This is a read-only operation.
 
     Args:
@@ -123,10 +127,10 @@ def read_email(email_id: str | None = None) -> dict:
                   returns all emails in the inbox.
 
     Returns:
-        Dictionary with a list of email messages.
+        ToolResult with a list of email messages in structured_content.
     """
     with trace_tool(tracer, "read_email"):
-        return _read(email_id)
+        return ToolResult(content=[], structured_content=_read(email_id))
 
 
 # ---------------------------------------------------------------------------

--- a/demos/agent-gateway/src/income-verification-api/main.py
+++ b/demos/agent-gateway/src/income-verification-api/main.py
@@ -15,6 +15,7 @@
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from fastmcp import FastMCP
+from fastmcp.tools.base import ToolResult
 from pydantic import BaseModel
 from starlette.applications import Starlette
 from starlette.responses import JSONResponse as StarletteJSONResponse
@@ -83,7 +84,7 @@ mcp = FastMCP(name="income-verification")
 
 
 @mcp.tool()
-def verify_applicant(first_name: str, last_name: str) -> dict:
+def verify_applicant(first_name: str, last_name: str) -> ToolResult:
     """Verify applicant income through third-party income verification service.
 
     Args:
@@ -91,16 +92,17 @@ def verify_applicant(first_name: str, last_name: str) -> dict:
         last_name: Applicant's last name.
 
     Returns:
-        Dictionary with verified income data from employer records.
+        ToolResult with verified income data in structured_content.
     """
+    # content=[] suppresses the duplicate raw-text representation; Model Armor's
+    # CONTENT_AUTHZ only redacts structuredContent, so leaving content[] populated
+    # leaks SSNs around the redactor.
     with trace_tool(tracer, "verify_applicant"):
-        result = _verify(first_name, last_name)
-        if result:
-            return result
-        return {
+        result = _verify(first_name, last_name) or {
             "status": "error",
             "error": f"No verification records found for {first_name} {last_name}.",
         }
+        return ToolResult(content=[], structured_content=result)
 
 
 # ---------------------------------------------------------------------------

--- a/demos/agent-gateway/src/legacy-dms/server.py
+++ b/demos/agent-gateway/src/legacy-dms/server.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 from fastmcp import FastMCP
+from fastmcp.tools.base import ToolResult
 from starlette.applications import Starlette
 from starlette.responses import JSONResponse
 from starlette.routing import Mount, Route
@@ -174,7 +175,7 @@ def _get_document(document_id: str) -> dict:
 
 
 @mcp.tool()
-def search_documents(applicant_last_name: str, document_type: str, years: int = 2) -> dict:
+def search_documents(applicant_last_name: str, document_type: str, years: int = 2) -> ToolResult:
     """Search the document management system for applicant documents.
 
     Args:
@@ -183,24 +184,27 @@ def search_documents(applicant_last_name: str, document_type: str, years: int = 
         years: Number of years of documents to retrieve (default 2).
 
     Returns:
-        Dictionary with matching document metadata.
+        ToolResult with matching document metadata in structured_content.
     """
+    # content=[] suppresses the duplicate raw-text representation; Model Armor's
+    # CONTENT_AUTHZ only redacts structuredContent, so leaving content[] populated
+    # leaks SSNs around the redactor.
     with trace_tool(tracer, "search_documents"):
-        return _search_documents(applicant_last_name, document_type, years)
+        return ToolResult(content=[], structured_content=_search_documents(applicant_last_name, document_type, years))
 
 
 @mcp.tool()
-def get_document(document_id: str) -> dict:
+def get_document(document_id: str) -> ToolResult:
     """Retrieve a full document from the document management system by ID.
 
     Args:
         document_id: The unique document identifier (e.g. 'DOC-2024-SM-1040').
 
     Returns:
-        Dictionary with the full document content.
+        ToolResult with the full document content in structured_content.
     """
     with trace_tool(tracer, "get_document"):
-        return _get_document(document_id)
+        return ToolResult(content=[], structured_content=_get_document(document_id))
 
 
 # ---------------------------------------------------------------------------

--- a/demos/agent-gateway/terraform/modules/model-armor/main.tf
+++ b/demos/agent-gateway/terraform/modules/model-armor/main.tf
@@ -65,6 +65,19 @@ resource "google_data_loss_prevention_deidentify_template" "ssn" {
   deidentify_config {
     info_type_transformations {
       transformations {
+        # Scope the replace transformation to ONLY the info types the operator
+        # asked for in var.pii_types. Without this filter, the transformation
+        # applies to every finding — and Model Armor's SDP filter detects
+        # PERSON_NAME on its own (alongside the custom inspect template),
+        # which then gets replaced with [PERSON_NAME] even though PERSON_NAME
+        # is not in var.pii_types. Listing the info types here makes findings
+        # of any other type pass through untransformed.
+        dynamic "info_types" {
+          for_each = var.pii_types
+          content {
+            name = info_types.value
+          }
+        }
         primitive_transformation {
           replace_with_info_type_config = true
         }

--- a/demos/agent-gateway/terraform/variables.tf
+++ b/demos/agent-gateway/terraform/variables.tf
@@ -265,7 +265,7 @@ variable "model_armor_sdp_enforcement" {
 }
 
 variable "model_armor_pii_types" {
-  description = "List of PII info types to detect and block"
+  description = "Info types whose findings the response Model Armor template's deidentify transformation replaces with the type-name placeholder. Model Armor's SDP filter still runs Google's built-in detectors (including PERSON_NAME) regardless of this list, but only findings whose info type appears here are transformed — anything else is passed through to the agent unchanged. Keep identity fields the agent needs for downstream reasoning (e.g. PERSON_NAME) OUT of this list."
   type        = list(string)
   default = [
     "US_SOCIAL_SECURITY_NUMBER",
@@ -277,7 +277,6 @@ variable "model_armor_pii_types" {
     "MEDICAL_RECORD_NUMBER",
     "IP_ADDRESS",
     "STREET_ADDRESS",
-    "PERSON_NAME"
   ]
 }
 


### PR DESCRIPTION
Two bugs were defeating Model Armor's SDP redaction on MCP tool responses heading back to the mortgage agent. This PR fixes both so the agent sees redacted SSNs/IDs but still receives the applicant's name it needs for downstream reasoning.

1) MCP servers were leaking unredacted duplicates around the redactor
2) Model Armor was redacting PERSON_NAME. 