### PR TITLE
feat(agent-gateway): fail-fast on denied tools and tighten authz timeout

### DIFF
--- a/demos/agent-gateway/src/mortgage-agent/agent/agent.py
+++ b/demos/agent-gateway/src/mortgage-agent/agent/agent.py
@@ -123,7 +123,7 @@ def _build_impersonation_factory(target_url: str, target_sa_email: str):
         return httpx.AsyncClient(
             follow_redirects=True,
             headers=headers,
-            timeout=timeout if timeout is not None else httpx.Timeout(30.0, read=300.0),
+            timeout=timeout if timeout is not None else httpx.Timeout(5.0),
             # Honor an explicit auth from the caller (rare); otherwise inject ours.
             auth=auth if auth is not None else auth_handler,
         )
@@ -224,19 +224,47 @@ def _find_http_status_error(exc: BaseException, status_code: int) -> bool:
     return False
 
 
+# Session-scoped key under which we count per-tool 403 attempts. Without this
+# the LLM will happily re-call a denied tool on every turn, multiplying the
+# authz extension's per-call budget into a multi-second loop.
+_DENIED_TOOLS_STATE_KEY = "_denied_mcp_tools"
+_MAX_403_ATTEMPTS = 2  # initial attempt + 1 retry
+
+
 def _handle_tool_error(
     tool: BaseTool, args: dict[str, Any], tool_context: ToolContext, error: Exception
 ) -> dict | None:
-    """Handle tool errors, returning a friendly message for 403 policy denials."""
-    if _find_http_status_error(error, 403):
-        logger.warning("Tool %s denied by authorization policy (403)", tool.name)
+    """Handle tool errors, returning a friendly message for 403 policy denials.
+
+    Tracks 403 count per tool name in `tool_context.state` so the LLM is told to
+    stop after _MAX_403_ATTEMPTS denials for the same tool within a session.
+    """
+    if not _find_http_status_error(error, 403):
+        return None
+    denied = dict(tool_context.state.get(_DENIED_TOOLS_STATE_KEY, {}))
+    attempts = denied.get(tool.name, 0) + 1
+    denied[tool.name] = attempts
+    tool_context.state[_DENIED_TOOLS_STATE_KEY] = denied
+    logger.warning(
+        "Tool %s denied by authorization policy (403) — attempt %d/%d",
+        tool.name,
+        attempts,
+        _MAX_403_ATTEMPTS,
+    )
+    if attempts >= _MAX_403_ATTEMPTS:
         return {
             "error": (
-                f"The '{tool.name}' tool call was denied by the authorization "
-                "gateway. This operation is not permitted by policy."
+                f"The '{tool.name}' tool was denied by the authorization gateway "
+                f"{attempts} times. Do not call this tool again in this session — "
+                "report the denial to the user and proceed with other tools."
             ),
         }
-    return None
+    return {
+        "error": (
+            f"The '{tool.name}' tool call was denied by the authorization "
+            "gateway. This operation is not permitted by policy."
+        ),
+    }
 
 
 def _discover_mcp_toolsets() -> list:
@@ -352,12 +380,11 @@ def _discover_mcp_toolsets() -> list:
         except Exception:
             logger.exception("Failed to build toolset for MCP server %s", name)
             continue
-        # ADK's StreamableHTTPConnectionParams default is 5s, which is shorter
-        # than a Cloud Run cold start when min_instance_count=0. Survive a
-        # restart/scale-out even when an instance happens to be cold.
+        # Use ADK's 5s StreamableHTTPConnectionParams default so denied calls
+        # fail fast. Cold-start tolerance is handled by keeping >=1 warm
+        # instance per MCP backend (terraform/example.tfvars), not by stretching
+        # the per-call budget.
         conn_params = getattr(toolset, "_connection_params", None)
-        if conn_params is not None and hasattr(conn_params, "timeout"):
-            conn_params.timeout = 30.0
         resolved_url = getattr(conn_params, "url", None)
         # Inject SA-impersonation auth so each MCP HTTP call carries an OIDC
         # ID token for the invoker SA. Cloud Run validates the token and sees

--- a/demos/agent-gateway/src/mortgage-agent/tests/test_agent.py
+++ b/demos/agent-gateway/src/mortgage-agent/tests/test_agent.py
@@ -72,29 +72,70 @@ class TestFindHttpStatusError:
         assert _find_http_status_error(outer_group, 403) is True
 
 
+def _make_tool_context(state: dict | None = None) -> MagicMock:
+    """ToolContext mock whose `.state` is a real dict so .get/__setitem__ work."""
+    ctx = MagicMock()
+    ctx.state = {} if state is None else state
+    return ctx
+
+
 class TestHandleToolError:
     def test_403_returns_friendly_message(self):
         tool = MagicMock()
         tool.name = "send_email"
         error = _make_http_status_error(403)
-        result = _handle_tool_error(tool, {}, MagicMock(), error)
+        result = _handle_tool_error(tool, {}, _make_tool_context(), error)
         assert result is not None
         assert "denied" in result["error"]
         assert "send_email" in result["error"]
+        # First attempt should not be the hard-stop wording.
+        assert "Do not call this tool again" not in result["error"]
 
     def test_non_403_returns_none(self):
         tool = MagicMock()
         tool.name = "read_email"
         error = _make_http_status_error(500)
-        result = _handle_tool_error(tool, {}, MagicMock(), error)
+        result = _handle_tool_error(tool, {}, _make_tool_context(), error)
         assert result is None
 
     def test_non_http_error_returns_none(self):
         tool = MagicMock()
         tool.name = "read_email"
         error = RuntimeError("something broke")
-        result = _handle_tool_error(tool, {}, MagicMock(), error)
+        result = _handle_tool_error(tool, {}, _make_tool_context(), error)
         assert result is None
+
+    def test_403_second_attempt_returns_hard_stop(self):
+        tool = MagicMock()
+        tool.name = "send_email"
+        error = _make_http_status_error(403)
+        ctx = _make_tool_context()
+
+        first = _handle_tool_error(tool, {}, ctx, error)
+        assert "Do not call this tool again" not in first["error"]
+
+        second = _handle_tool_error(tool, {}, ctx, error)
+        assert "Do not call this tool again" in second["error"]
+        assert ctx.state["_denied_mcp_tools"]["send_email"] == 2
+
+    def test_403_per_tool_counters_are_independent(self):
+        tool_a = MagicMock()
+        tool_a.name = "send_email"
+        tool_b = MagicMock()
+        tool_b.name = "read_email"
+        error = _make_http_status_error(403)
+        ctx = _make_tool_context()
+
+        # Tool A hits the cap.
+        _handle_tool_error(tool_a, {}, ctx, error)
+        _handle_tool_error(tool_a, {}, ctx, error)
+        assert ctx.state["_denied_mcp_tools"]["send_email"] == 2
+
+        # Tool B's first attempt is still the friendly (non-hard-stop) message.
+        result = _handle_tool_error(tool_b, {}, ctx, error)
+        assert "Do not call this tool again" not in result["error"]
+        assert "denied" in result["error"]
+        assert ctx.state["_denied_mcp_tools"]["read_email"] == 1
 
 
 class TestInstructionRendering:
@@ -150,18 +191,17 @@ class TestInstructionRendering:
         assert "`income_*`" not in instruction
 
 
-class TestConnectionTimeoutOverride:
-    """ADK's 5s default trips on Cloud Run cold starts; we override it to 30s."""
+class TestConnectionTimeoutNoMutation:
+    """We rely on ADK's 5s default for fail-fast on denied calls; do not mutate it."""
 
-    def test_discover_overrides_toolset_timeout(self, monkeypatch):
+    def test_discover_does_not_override_toolset_timeout(self, monkeypatch):
         monkeypatch.setenv("MCP_REGISTRY_PROJECT", "test-project")
         monkeypatch.setenv("MCP_REGISTRY_LOCATION", "us-central1")
         monkeypatch.delenv("MCP_REGISTRY_FILTER", raising=False)
         monkeypatch.delenv("MCP_REGISTRY_ENDPOINT", raising=False)
 
-        # Connection params object whose timeout we expect to be mutated.
         conn_params = MagicMock()
-        conn_params.timeout = 5.0
+        conn_params.timeout = 5.0  # ADK default
         conn_params.url = "https://x.example/mcp"
 
         toolset = MagicMock()
@@ -181,4 +221,4 @@ class TestConnectionTimeoutOverride:
             result = _discover_mcp_toolsets()
 
         assert result == [toolset]
-        assert conn_params.timeout == 30.0
+        assert conn_params.timeout == 5.0

--- a/demos/agent-gateway/terraform/modules/agent-gateway/variables.tf
+++ b/demos/agent-gateway/terraform/modules/agent-gateway/variables.tf
@@ -76,7 +76,7 @@ variable "model_armor_authz_hosts" {
 variable "authz_extension_timeout" {
   description = "gRPC call timeout for the authz extensions (string format e.g. \"1s\")"
   type        = string
-  default     = "5s"
+  default     = "2s"
 }
 
 variable "authz_extension_fail_open" {


### PR DESCRIPTION
## Summary

Make denied tool calls surface in seconds instead of looping for tens of seconds.

- **authz extension timeout**: 5s → 2s (`agent-gateway/terraform/modules/agent-gateway/variables.tf`)
- **mortgage-agent LLM timeouts**: drop the 30s `conn_params.timeout` override and the 30s/300s httpx default in the impersonation factory; rely on ADK's 5s `StreamableHTTPConnectionParams` default so denied calls surface promptly. Cold-start tolerance is handled by keeping >=1 warm instance per MCP backend.
- **bounded 403 retries**: track per-tool 403 attempts in `tool_context.state` and return a hard-stop message after the second denial so the LLM stops re-calling a tool the authz gateway has already refused.

Combined effect: a denied tool now costs ~4s worst case instead of looping.