### PR TITLE
fix(mortgage-agent): unblock Reasoning Engine redeploy + add Cloud Build bucket override

### DIFF
--- a/demos/agent-gateway/src/mortgage-agent/agent/agent.py
+++ b/demos/agent-gateway/src/mortgage-agent/agent/agent.py
@@ -137,6 +137,16 @@ def _build_impersonation_factory(target_url: str, target_sa_email: str):
 # up without re-querying the registry.
 DISCOVERED_MCP_SERVERS: list[dict[str, Any]] = []
 
+# Populated once per process by _discover_mcp_toolsets(). Reused on every
+# subsequent call so Reasoning Engine unpickling (which re-runs
+# _PickleSafeAgent.__reduce__ -> _build_agent -> _discover_mcp_toolsets) does
+# not construct a second MCPSessionManager in the same process, which trips
+# "Context has already been used to create a Connection" inside ADK/anyio.
+# Empty results are cached too so a failing discovery is not retried (and
+# re-warned) on every unpickle. Membership is therefore frozen per worker
+# process; new MCP servers require a redeploy or worker restart.
+_CACHED_TOOLSETS: list | None = None
+
 # Per-service prose, keyed by registry displayName. Entries here get rendered
 # into the instruction's MCP services block alongside each service's live
 # tool_name_prefix. Services discovered without a matching entry render with
@@ -287,6 +297,14 @@ def _discover_mcp_toolsets() -> list:
     aborting agent startup, so the agent still boots (with utility tools only)
     if the registry is unreachable.
     """
+    global _CACHED_TOOLSETS
+    if _CACHED_TOOLSETS is not None:
+        logger.debug(
+            "Reusing %d cached MCP toolset(s); skipping registry discovery.",
+            len(_CACHED_TOOLSETS),
+        )
+        return _CACHED_TOOLSETS
+
     DISCOVERED_MCP_SERVERS.clear()
 
     project = os.environ.get("MCP_REGISTRY_PROJECT") or os.environ.get("GOOGLE_CLOUD_PROJECT")
@@ -305,7 +323,8 @@ def _discover_mcp_toolsets() -> list:
             project,
             location,
         )
-        return []
+        _CACHED_TOOLSETS = []
+        return _CACHED_TOOLSETS
 
     filter_str = os.environ.get("MCP_REGISTRY_FILTER")
     endpoint = os.environ.get("MCP_REGISTRY_ENDPOINT")
@@ -331,7 +350,8 @@ def _discover_mcp_toolsets() -> list:
             "is missing a transitive dep (typically a2a-sdk).",
             e,
         )
-        return []
+        _CACHED_TOOLSETS = []
+        return _CACHED_TOOLSETS
 
     try:
         if endpoint:
@@ -349,7 +369,8 @@ def _discover_mcp_toolsets() -> list:
             location,
             effective_endpoint,
         )
-        return []
+        _CACHED_TOOLSETS = []
+        return _CACHED_TOOLSETS
 
     raw_servers = response.get("mcpServers", [])
     effective_endpoint = endpoint or getattr(_ar_module, "AGENT_REGISTRY_BASE_URL", "<adk-default>")
@@ -434,7 +455,8 @@ def _discover_mcp_toolsets() -> list:
             effective_endpoint,
         )
 
-    return toolsets
+    _CACHED_TOOLSETS = toolsets
+    return _CACHED_TOOLSETS
 
 
 class _PickleSafeAgent(Agent):

--- a/demos/agent-gateway/src/mortgage-agent/agent/otel_setup.py
+++ b/demos/agent-gateway/src/mortgage-agent/agent/otel_setup.py
@@ -16,7 +16,7 @@
 
 from __future__ import annotations
 
-from vertexai.agent_engines.templates.adk import AdkApp
+from vertexai.agent_engines import AdkApp
 
 
 class InstrumentedAdkApp(AdkApp):

--- a/demos/agent-gateway/src/mortgage-agent/deploy_agent.py
+++ b/demos/agent-gateway/src/mortgage-agent/deploy_agent.py
@@ -528,17 +528,27 @@ def main() -> None:
         deploy_config = dict(
             staging_bucket=staging_bucket,
             requirements=[
-                "google-cloud-aiplatform[adk,agent_engines]",
-                # --- BEGIN TEMPORARY OVERRIDE: track adk-python main ---
-                # Remove this line (and restore the PyPI google-adk dep) once
-                # the upstream fix we need lands in a tagged release.
+                # Upper-bound pin keeps the container on a release where
+                # `vertexai.agent_engines.AdkApp` (the public import used by
+                # agent/otel_setup.py) resolves the same class the operator
+                # pickled. Unpinned, PyPI advanced to 1.153.1 which had already
+                # removed the older `vertexai.agent_engines.templates.adk` path
+                # and broke unpickle in the container. The `[adk]` extra is
+                # omitted because google-adk is pinned explicitly below; the
+                # extra would just re-declare the same dep with a looser
+                # range. Keep aligned with pyproject.toml.
+                "google-cloud-aiplatform[agent_engines]>=1.149.0,<1.154.0",
+                # Pin google-adk to a tagged PyPI release (was previously
+                # tracking adk-python@main, which started publishing 2.0.0b1
+                # and conflicted with google-cloud-aiplatform's [adk] extra).
                 # The [a2a,agent-identity] extras pull a2a-sdk and
-                # google-cloud-iamconnectorcredentials at versions google-adk
-                # itself requires — without them registry discovery fails on
-                # `cannot import name 'TransportProtocol'` (a2a) or
+                # google-cloud-iamconnectorcredentials at the versions
+                # google-adk itself requires — without them registry
+                # discovery fails on `cannot import name 'TransportProtocol'`
+                # (a2a) or
                 # `No module named google.cloud.iamconnectorcredentials_v1alpha`.
-                "google-adk[a2a,agent-identity] @ git+https://github.com/google/adk-python.git@main",
-                # --- END TEMPORARY OVERRIDE ---
+                # Keep aligned with pyproject.toml.
+                "google-adk[a2a,agent-identity]==1.34.0",
                 "google-auth>=2.0",
                 "cloudpickle",
                 "pydantic",

--- a/demos/agent-gateway/src/mortgage-agent/pyproject.toml
+++ b/demos/agent-gateway/src/mortgage-agent/pyproject.toml
@@ -20,9 +20,17 @@ requires-python = ">=3.12"
 dependencies = [
     # The [a2a,agent-identity] extras pull a2a-sdk and
     # google-cloud-iamconnectorcredentials at the versions google-adk's
-    # agent_registry integration requires.
-    "google-adk[a2a,agent-identity]>=1.31.0",
-    "google-cloud-aiplatform>=1.74.0",
+    # agent_registry integration requires. Pinned to match the same
+    # version the container installs via deploy_agent.py's requirements.
+    "google-adk[a2a,agent-identity]==1.34.0",
+    # Pinned to a tested range so the operator's pickle blob and the container's
+    # AdkApp import stay class-compatible. agent/otel_setup.py uses the public
+    # path `from vertexai.agent_engines import AdkApp`, which is present in both
+    # 1.149.0 and 1.153.1; the internal `vertexai.agent_engines.templates.adk`
+    # path was already removed by 1.153.1, so an unpinned container deploy
+    # silently broke when PyPI advanced. Keep deploy_agent.py's requirements
+    # list aligned to the same upper bound.
+    "google-cloud-aiplatform>=1.149.0,<1.154.0",
     "opentelemetry-instrumentation-google-genai",
     "opentelemetry-instrumentation-grpc",
     "opentelemetry-instrumentation-fastapi",

--- a/demos/agent-gateway/src/mortgage-agent/uv.lock
+++ b/demos/agent-gateway/src/mortgage-agent/uv.lock
@@ -562,7 +562,7 @@ wheels = [
 
 [[package]]
 name = "google-adk"
-version = "1.31.1"
+version = "1.34.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiosqlite" },
@@ -611,9 +611,9 @@ dependencies = [
     { name = "watchdog" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/f7/e2371e8a871202f47f8911992da7daf8623dd61e714e0af5c6fec019ba67/google_adk-1.31.1.tar.gz", hash = "sha256:e56416264f62e931709da6262bc9fe05140faeb7a889a2fe8f5684617e8a05c3", size = 2408228, upload-time = "2026-04-21T02:06:48.623Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/dc/1fec30bdc7b640087ee64dfc69bae4450ef43a1cba688bd9cb99dca6ba67/google_adk-1.34.0.tar.gz", hash = "sha256:bce56f6f8f400dcc83d633190f5f44d27fcb88a515a9556aeeb9ef9cbc896600", size = 2431386, upload-time = "2026-05-18T23:48:00.212Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/02/6e7b88b122708569004ac024ec7f6773cc9d10ce1b086a4a6668a95ca142/google_adk-1.31.1-py3-none-any.whl", hash = "sha256:8f5d9c67c9a87832c2fe581bd4b1248dddf8964c98351a38e2663f0999bc7209", size = 2850553, upload-time = "2026-04-21T02:06:45.992Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/86/7d9e222e1ee6dd9719844d5fad4ba25c9ec8c4191ee2644a81bd04749c6b/google_adk-1.34.0-py3-none-any.whl", hash = "sha256:928340bc4b6bd3de8bfa780d3971d4c1bb10e48a52fb66875f273ba42d72b669", size = 2876260, upload-time = "2026-05-18T23:48:02.296Z" },
 ]
 
 [package.optional-dependencies]
@@ -1590,8 +1590,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "google-adk", extras = ["a2a", "agent-identity"], specifier = ">=1.31.0" },
-    { name = "google-cloud-aiplatform", specifier = ">=1.74.0" },
+    { name = "google-adk", extras = ["a2a", "agent-identity"], specifier = "==1.34.0" },
+    { name = "google-cloud-aiplatform", specifier = ">=1.149.0,<1.154.0" },
     { name = "opentelemetry-instrumentation-fastapi" },
     { name = "opentelemetry-instrumentation-google-genai" },
     { name = "opentelemetry-instrumentation-grpc" },

--- a/demos/agent-gateway/terraform/main.tf
+++ b/demos/agent-gateway/terraform/main.tf
@@ -141,7 +141,7 @@ resource "google_artifact_registry_repository" "registry" {
 # Cloud Build — Source bucket for regional Cloud Build submissions
 resource "google_storage_bucket" "cloudbuild" {
   project                     = var.project_id
-  name                        = "${var.project_id}_cloudbuild"
+  name                        = coalesce(var.cloudbuild_bucket_name, "${var.project_id}_cloudbuild")
   location                    = var.region
   uniform_bucket_level_access = true
   force_destroy               = false

--- a/demos/agent-gateway/terraform/variables.tf
+++ b/demos/agent-gateway/terraform/variables.tf
@@ -54,6 +54,12 @@ variable "platform_admin_members" {
   default     = []
 }
 
+variable "cloudbuild_bucket_name" {
+  description = "Override the Cloud Build source bucket name. Defaults to <project_id>_cloudbuild, which matches the bucket gcloud/Cloud Build SDKs auto-pick when no --gcs-source-staging-dir is passed; overriding the name breaks that convenience."
+  type        = string
+  default     = null
+}
+
 # ==============================================================================
 # NETWORKING CONFIGURATION
 # ==============================================================================


### PR DESCRIPTION
## Summary

- **fix(mortgage-agent)**: cache discovered MCP toolsets at module scope so
  they survive Reasoning Engine unpickling, switch `agent/otel_setup.py` to
  the public `from vertexai.agent_engines import AdkApp` import, and pin
  Python deps (`google-adk==1.34.0`,
  `google-cloud-aiplatform>=1.149.0,<1.154.0`) so the operator's pickle blob
  and the container's installed SDKs stay class-compatible.
- **feat(agent-gateway)**: add an optional `cloudbuild_bucket_name`
  Terraform variable so users can override the default
  `<project_id>_cloudbuild` source bucket name.