### PR TITLE
fix(agent-gateway): set Cloud Run custom audiences for private MCP hosts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ Thumbs.db
 
 # Direnv
 .direnv/
+
+# JJ workspaces
+.workspaces/

--- a/demos/agent-gateway/src/mortgage-agent/agent/agent.py
+++ b/demos/agent-gateway/src/mortgage-agent/agent/agent.py
@@ -132,9 +132,11 @@ def _build_impersonation_factory(target_url: str, target_sa_email: str):
 
 
 # Populated by _discover_mcp_toolsets at agent build time. Each entry mirrors
-# what the registry returned plus the resolved tool_name_prefix, so the
-# `list_mcp_connections` introspection tool can report what is actually wired
-# up without re-querying the registry.
+# what the registry returned plus the resolved tool_name_prefix and the list
+# of unprefixed tool names the registry advertised for that server, so the
+# instruction template can enumerate exact tool names (preventing LLM
+# hallucination) and the `list_mcp_connections` introspection tool can report
+# what is actually wired up without re-querying the registry.
 DISCOVERED_MCP_SERVERS: list[dict[str, Any]] = []
 
 # Populated once per process by _discover_mcp_toolsets(). Reused on every
@@ -146,6 +148,14 @@ DISCOVERED_MCP_SERVERS: list[dict[str, Any]] = []
 # re-warned) on every unpickle. Membership is therefore frozen per worker
 # process; new MCP servers require a redeploy or worker restart.
 _CACHED_TOOLSETS: list | None = None
+
+# Companion cache for DISCOVERED_MCP_SERVERS. The instruction template is
+# rendered from DISCOVERED_MCP_SERVERS, so on a cache hit we must restore the
+# list from this snapshot — otherwise a future cross-process unpickle (where
+# module globals are reset but _CACHED_TOOLSETS is somehow rehydrated) would
+# render an empty instruction and reintroduce the hallucination this caching
+# is meant to prevent.
+_CACHED_DISCOVERED: list[dict[str, Any]] | None = None
 
 # Per-service prose, keyed by registry displayName. Entries here get rendered
 # into the instruction's MCP services block alongside each service's live
@@ -174,9 +184,10 @@ _INSTRUCTION_TEMPLATE = """You are a mortgage underwriting assistant. You help l
 mortgage applications by retrieving documents, verifying income, and communicating results.
 
 You connect to backend systems through an Agent Gateway. The set of available tools is
-discovered from the Agent Registry at startup and can change between deployments. Each
-MCP service contributes tools with a service-specific prefix; only call tools whose
-prefix appears in the list below.
+discovered from the Agent Registry at startup and may change between deployments.
+**Only call tools by the exact names listed below.** Tool names use underscores as
+separators (e.g. `legacy_dms_search_documents`); never use a colon (`:`), slash, dot,
+or any other separator.
 
 **MCP services discovered from the registry:**
 {mcp_services_doc}
@@ -191,6 +202,9 @@ prefix appears in the list below.
 - NEVER fabricate or estimate financial figures. Only report data returned by tools.
 - Always cite which tool/system provided each piece of data.
 - If a tool call fails or returns an error, report the error honestly to the user.
+- **Never invent tool names.** Only call tools whose exact names appear in the MCP
+services list above or in the utility tools list below. If no listed tool matches your
+need, tell the user you cannot perform that operation rather than guessing at a name.
 - Be concise and professional in all responses.
 - When presenting tax return or applicant data, ALWAYS include the SSN field and display its value
 exactly as returned by the tool (e.g. "[US_SOCIAL_SECURITY_NUMBER]"). Never omit SSN fields.
@@ -201,16 +215,30 @@ You also have utility tools:
 
 
 def _render_mcp_services_doc() -> str:
-    """Render the per-service block from the live DISCOVERED_MCP_SERVERS list."""
+    """Render the per-service block from the live DISCOVERED_MCP_SERVERS list.
+
+    Enumerates the exact prefixed tool names the LLM is allowed to call. The
+    wildcard form (`prefix_*`) is only used as a fallback when the registry
+    response didn't include a tool list — leaving the wildcard in the prompt
+    when concrete names are known invites the LLM to invent plausible-sounding
+    names that don't exist.
+    """
     if not DISCOVERED_MCP_SERVERS:
         return "_(no MCP services discovered — only utility tools are available)_"
     lines: list[str] = []
     for entry in DISCOVERED_MCP_SERVERS:
-        prefix = entry.get("tool_name_prefix") or "(none)"
+        prefix = entry.get("tool_name_prefix")
         name = entry.get("name") or entry.get("resource_name") or "?"
+        tool_names = entry.get("tools") or []
         desc = _SERVICE_DESCRIPTIONS.get(name)
         suffix = f" — connects to {desc}" if desc else ""
-        lines.append(f"- **{name}** (tools prefixed `{prefix}_*`){suffix}")
+        if prefix and tool_names:
+            full = ", ".join(f"`{prefix}_{t}`" for t in tool_names)
+            lines.append(f"- **{name}** (tools: {full}){suffix}")
+        elif prefix:
+            lines.append(f"- **{name}** (tools prefixed `{prefix}_*`){suffix}")
+        else:
+            lines.append(f"- **{name}** (no tools advertised){suffix}")
     return "\n".join(lines)
 
 
@@ -297,12 +325,16 @@ def _discover_mcp_toolsets() -> list:
     aborting agent startup, so the agent still boots (with utility tools only)
     if the registry is unreachable.
     """
-    global _CACHED_TOOLSETS
+    global _CACHED_TOOLSETS, _CACHED_DISCOVERED
     if _CACHED_TOOLSETS is not None:
         logger.debug(
             "Reusing %d cached MCP toolset(s); skipping registry discovery.",
             len(_CACHED_TOOLSETS),
         )
+        # Keep DISCOVERED_MCP_SERVERS in sync with the cached toolsets so the
+        # instruction renderer always sees the same view as the toolset list.
+        DISCOVERED_MCP_SERVERS.clear()
+        DISCOVERED_MCP_SERVERS.extend(_CACHED_DISCOVERED or [])
         return _CACHED_TOOLSETS
 
     DISCOVERED_MCP_SERVERS.clear()
@@ -324,6 +356,7 @@ def _discover_mcp_toolsets() -> list:
             location,
         )
         _CACHED_TOOLSETS = []
+        _CACHED_DISCOVERED = []
         return _CACHED_TOOLSETS
 
     filter_str = os.environ.get("MCP_REGISTRY_FILTER")
@@ -351,6 +384,7 @@ def _discover_mcp_toolsets() -> list:
             e,
         )
         _CACHED_TOOLSETS = []
+        _CACHED_DISCOVERED = []
         return _CACHED_TOOLSETS
 
     try:
@@ -370,6 +404,7 @@ def _discover_mcp_toolsets() -> list:
             effective_endpoint,
         )
         _CACHED_TOOLSETS = []
+        _CACHED_DISCOVERED = []
         return _CACHED_TOOLSETS
 
     raw_servers = response.get("mcpServers", [])
@@ -435,6 +470,10 @@ def _discover_mcp_toolsets() -> list:
                 "resource_name": name,
                 "tool_name_prefix": getattr(toolset, "tool_name_prefix", None),
                 "resolved_url": resolved_url,
+                # Unprefixed tool names from the registry payload. The
+                # instruction renderer prefixes them at render time so the
+                # LLM sees the exact names ADK will accept.
+                "tools": [t.get("name") for t in server.get("tools", []) if t.get("name")],
             }
         )
 
@@ -456,6 +495,7 @@ def _discover_mcp_toolsets() -> list:
         )
 
     _CACHED_TOOLSETS = toolsets
+    _CACHED_DISCOVERED = list(DISCOVERED_MCP_SERVERS)
     return _CACHED_TOOLSETS
 
 

--- a/demos/agent-gateway/src/mortgage-agent/tests/test_agent.py
+++ b/demos/agent-gateway/src/mortgage-agent/tests/test_agent.py
@@ -139,20 +139,41 @@ class TestHandleToolError:
 
 
 class TestInstructionRendering:
-    """The instruction must reflect the live registry prefixes, not hardcoded ones."""
+    """The instruction must enumerate live registry tool names, not just prefixes,
+    so the LLM has no room to invent plausible-but-wrong tool names."""
 
     _DISCOVERED = [
-        {"name": "legacy-dms", "tool_name_prefix": "legacy_dms"},
-        {"name": "corporate-email", "tool_name_prefix": "corporate_email"},
-        {"name": "income-verification", "tool_name_prefix": "income_verification"},
+        {
+            "name": "legacy-dms",
+            "tool_name_prefix": "legacy_dms",
+            "tools": ["search_documents", "get_document"],
+        },
+        {
+            "name": "corporate-email",
+            "tool_name_prefix": "corporate_email",
+            "tools": ["list_messages", "get_message"],
+        },
+        {
+            "name": "income-verification",
+            "tool_name_prefix": "income_verification",
+            "tools": ["verify_income"],
+        },
     ]
 
-    def test_render_includes_live_prefixes_and_descriptions(self):
+    def test_render_includes_live_tool_names_and_descriptions(self):
         with patch.object(agent_module, "DISCOVERED_MCP_SERVERS", self._DISCOVERED):
             doc = _render_mcp_services_doc()
-        assert "`legacy_dms_*`" in doc
-        assert "`corporate_email_*`" in doc
-        assert "`income_verification_*`" in doc
+        # Concrete prefixed names appear.
+        assert "`legacy_dms_search_documents`" in doc
+        assert "`legacy_dms_get_document`" in doc
+        assert "`corporate_email_list_messages`" in doc
+        assert "`corporate_email_get_message`" in doc
+        assert "`income_verification_verify_income`" in doc
+        # The wildcard form must NOT appear when tools are known — that
+        # wildcard is what gave the LLM rope to invent names.
+        assert "`legacy_dms_*`" not in doc
+        assert "`corporate_email_*`" not in doc
+        assert "`income_verification_*`" not in doc
         # Descriptions for known services come through.
         assert "legacy document management system" in doc
         assert "corporate communications system" in doc
@@ -163,7 +184,35 @@ class TestInstructionRendering:
             doc = _render_mcp_services_doc()
         assert "no MCP services discovered" in doc
 
-    def test_render_handles_unknown_service(self):
+    def test_render_handles_unknown_service_with_tools(self):
+        with patch.object(
+            agent_module,
+            "DISCOVERED_MCP_SERVERS",
+            [
+                {
+                    "name": "future-service",
+                    "tool_name_prefix": "future_service",
+                    "tools": ["do_thing"],
+                }
+            ],
+        ):
+            doc = _render_mcp_services_doc()
+        assert "**future-service** (tools: `future_service_do_thing`)" in doc
+        # No description prose appended for unknown services.
+        assert "connects to" not in doc
+
+    def test_render_falls_back_to_wildcard_when_tools_empty(self):
+        with patch.object(
+            agent_module,
+            "DISCOVERED_MCP_SERVERS",
+            [{"name": "future-service", "tool_name_prefix": "future_service", "tools": []}],
+        ):
+            doc = _render_mcp_services_doc()
+        assert "**future-service** (tools prefixed `future_service_*`)" in doc
+
+    def test_render_handles_service_with_no_tools_field(self):
+        # An entry that has neither `tools` key set nor a populated list —
+        # `entry.get("tools") or []` must coerce both to the same fallback.
         with patch.object(
             agent_module,
             "DISCOVERED_MCP_SERVERS",
@@ -171,24 +220,35 @@ class TestInstructionRendering:
         ):
             doc = _render_mcp_services_doc()
         assert "**future-service** (tools prefixed `future_service_*`)" in doc
-        # No description prose appended for unknown services.
-        assert "connects to" not in doc
 
-    def test_built_agent_instruction_contains_live_prefixes(self):
+    def test_render_handles_service_with_no_prefix_and_no_tools(self):
+        with patch.object(
+            agent_module,
+            "DISCOVERED_MCP_SERVERS",
+            [{"name": "broken-service"}],
+        ):
+            doc = _render_mcp_services_doc()
+        assert "**broken-service** (no tools advertised)" in doc
+
+    def test_built_agent_instruction_contains_live_tool_names_and_guardrails(self):
         with (
             patch.object(agent_module, "_discover_mcp_toolsets", return_value=[]),
             patch.object(agent_module, "DISCOVERED_MCP_SERVERS", self._DISCOVERED),
         ):
             built = agent_module._build_agent()
         instruction = built.instruction
-        # New prefixes present.
-        assert "`legacy_dms_*`" in instruction
-        assert "`corporate_email_*`" in instruction
-        assert "`income_verification_*`" in instruction
-        # Stale hardcoded prefixes are gone.
-        assert "`dms_*`" not in instruction
-        assert "`email_*`" not in instruction
-        assert "`income_*`" not in instruction
+        # Concrete prefixed names present.
+        assert "`legacy_dms_search_documents`" in instruction
+        assert "`legacy_dms_get_document`" in instruction
+        assert "`income_verification_verify_income`" in instruction
+        # Wildcard form must NOT leak through when tools are known.
+        assert "`legacy_dms_*`" not in instruction
+        assert "`corporate_email_*`" not in instruction
+        assert "`income_verification_*`" not in instruction
+        # Anti-hallucination guardrails are in place.
+        assert "Only call tools by the exact names listed below." in instruction
+        assert "never use a colon (`:`)" in instruction
+        assert "Never invent tool names." in instruction
 
 
 class TestConnectionTimeoutNoMutation:
@@ -210,9 +270,20 @@ class TestConnectionTimeoutNoMutation:
 
         registry_instance = MagicMock()
         registry_instance.list_mcp_servers.return_value = {
-            "mcpServers": [{"name": "projects/p/locations/l/mcpServers/x", "displayName": "x"}]
+            "mcpServers": [
+                {
+                    "name": "projects/p/locations/l/mcpServers/x",
+                    "displayName": "x",
+                    "tools": [{"name": "do_thing"}],
+                }
+            ]
         }
         registry_instance.get_mcp_toolset.return_value = toolset
+
+        # Reset module-level cache so the discovery actually runs (other
+        # tests in this file may have populated it via real or mocked calls).
+        agent_module._CACHED_TOOLSETS = None
+        agent_module._CACHED_DISCOVERED = None
 
         with patch(
             "google.adk.integrations.agent_registry.AgentRegistry",
@@ -222,3 +293,7 @@ class TestConnectionTimeoutNoMutation:
 
         assert result == [toolset]
         assert conn_params.timeout == 5.0
+        # Unprefixed tool names from the registry payload land in
+        # DISCOVERED_MCP_SERVERS so the instruction renderer can enumerate
+        # exact names (preventing hallucination).
+        assert agent_module.DISCOVERED_MCP_SERVERS[0]["tools"] == ["do_thing"]

--- a/demos/agent-gateway/terraform/main.tf
+++ b/demos/agent-gateway/terraform/main.tf
@@ -357,10 +357,11 @@ resource "google_dns_record_set" "apigee_northbound" {
 module "mcp_services" {
   source = "./modules/mcp-cloud-run"
 
-  project_id         = var.project_id
-  region             = var.region
-  services           = var.mcp_services
-  private_networking = var.enable_cloud_run_private_networking
+  project_id              = var.project_id
+  region                  = var.region
+  services                = var.mcp_services
+  private_networking      = var.enable_cloud_run_private_networking
+  mcp_internal_dns_domain = local.mcp_internal_dns_domain_or_null
   # Restricts roles/run.invoker to the agent-mcp-invoker SA. Null when
   # agent_engine is disabled, in which case mcp-cloud-run skips the binding
   # and Cloud Run is unreachable until invoker is granted out-of-band.

--- a/demos/agent-gateway/terraform/modules/mcp-cloud-run/main.tf
+++ b/demos/agent-gateway/terraform/modules/mcp-cloud-run/main.tf
@@ -62,6 +62,15 @@ resource "google_cloud_run_v2_service" "mcp" {
   ingress             = var.private_networking ? "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER" : "INGRESS_TRAFFIC_ALL"
   deletion_protection = false
 
+  # On the private path the agent reaches each service via the internal LB at
+  # `https://<name>.<domain>` and mints an OIDC token scoped to that origin.
+  # Cloud Run only accepts tokens whose `aud` matches a *.run.app URL unless
+  # the custom host is registered here, so without this the LB-fronted calls
+  # return 401. Null on the public path leaves the default *.run.app audience.
+  custom_audiences = var.private_networking && var.mcp_internal_dns_domain != null ? [
+    "https://${each.key}.${trimsuffix(var.mcp_internal_dns_domain, ".")}"
+  ] : null
+
   template {
     service_account = google_service_account.mcp[each.key].email
 

--- a/demos/agent-gateway/terraform/modules/mcp-cloud-run/variables.tf
+++ b/demos/agent-gateway/terraform/modules/mcp-cloud-run/variables.tf
@@ -59,3 +59,9 @@ variable "invoker_sa_email" {
   type        = string
   default     = null
 }
+
+variable "mcp_internal_dns_domain" {
+  description = "Internal DNS domain fronting the MCP services behind the internal LB (e.g. \"mcp.example.com.\"). When set and private_networking is true, each service registers `https://<name>.<domain>` as a Cloud Run custom audience so it accepts the OIDC token the agent mints for the LB-fronted host (the agent's audience is the request origin, not the *.run.app URL). Null on the public *.run.app path."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## Problem

With `enable_cloud_run_private_networking = true`, the agent reaches each MCP Cloud Run service through the internal Application LB at its custom host (`https://<service>.mcp.<domain>/mcp`) rather than the `*.run.app` URL. The agent mints an OIDC ID token whose audience is the **origin** of that URL — `https://<service>.mcp.<domain>` (`src/mortgage-agent/agent/agent.py:49-56` builds `f"{parsed.scheme}://{parsed.netloc}"`).

Cloud Run only accepts ID tokens whose `aud` matches one of its `*.run.app` URLs by default, so it rejects the custom-host token with **401 Unauthorized**. This was observed across `income-verification`, `legacy-dms`, and the third MCP service in the Step 14 agent test (`Failed to get tools from toolset AgentRegistrySingleMcpToolset`).

## Fix

Register the LB-fronted custom host as a Cloud Run **custom audience** so the service trusts the token the agent already sends. No agent/code change needed.

- **`terraform/modules/mcp-cloud-run/variables.tf`** — new `mcp_internal_dns_domain` input (default `null`).
- **`terraform/modules/mcp-cloud-run/main.tf`** — `custom_audiences = ["https://${each.key}.${trimsuffix(domain, ".")}"]` on `google_cloud_run_v2_service.mcp`, gated on `private_networking && mcp_internal_dns_domain != null`; `null` otherwise.
- **`terraform/main.tf`** — pass the existing `local.mcp_internal_dns_domain_or_null` into the `mcp_services` module block.

The rendered audience exactly matches the token's `aud`. The public `*.run.app` codelab path is unaffected: when private networking is off the audience resolves to `null` (no diff vs. today).

## Verification

- `terraform fmt`, `terraform validate`, and `pre-commit` all pass.
- End-to-end: `terraform apply` in a private-networking project, then re-run the Step 14 agent test — the `POST .../mcp` calls should flip from 401 to 200 and the `AgentRegistrySingleMcpToolset` warnings should clear.