### PR TITLE
fix(mortgage-agent): fail-fast on 403 denials and harden telemetry/MCP Errors

### DIFF
--- a/demos/agent-gateway/src/mortgage-agent/agent/__init__.py
+++ b/demos/agent-gateway/src/mortgage-agent/agent/__init__.py
@@ -17,6 +17,16 @@ import sys
 
 sys.path.insert(0, os.path.dirname(__file__))
 
+# Prevent urllib3 from using PyOpenSSL, which contains a bug causing
+# "ValueError: Context has already been used to create a Connection"
+# when OTEL span exporter attempts to push telemetry after an HTTP error.
+try:
+    import urllib3.contrib.pyopenssl
+
+    urllib3.contrib.pyopenssl.extract_from_urllib3()
+except Exception:
+    pass
+
 import google.auth
 
 from . import agent  # noqa: F401

--- a/demos/agent-gateway/src/mortgage-agent/agent/agent.py
+++ b/demos/agent-gateway/src/mortgage-agent/agent/agent.py
@@ -266,7 +266,7 @@ def _find_http_status_error(exc: BaseException, status_code: int) -> bool:
 # the LLM will happily re-call a denied tool on every turn, multiplying the
 # authz extension's per-call budget into a multi-second loop.
 _DENIED_TOOLS_STATE_KEY = "_denied_mcp_tools"
-_MAX_403_ATTEMPTS = 2  # initial attempt + 1 retry
+_MAX_403_ATTEMPTS = 1  # No retries for 403 errors, fail immediately
 
 
 def _handle_tool_error(
@@ -274,8 +274,8 @@ def _handle_tool_error(
 ) -> dict | None:
     """Handle tool errors, returning a friendly message for 403 policy denials.
 
-    Tracks 403 count per tool name in `tool_context.state` so the LLM is told to
-    stop after _MAX_403_ATTEMPTS denials for the same tool within a session.
+    Tracks 403 count per tool name in `tool_context.state` and fails immediately
+    (no retries) — every 403 tells the LLM to stop calling the tool this session.
     """
     if not _find_http_status_error(error, 403):
         return None
@@ -289,18 +289,12 @@ def _handle_tool_error(
         attempts,
         _MAX_403_ATTEMPTS,
     )
-    if attempts >= _MAX_403_ATTEMPTS:
-        return {
-            "error": (
-                f"The '{tool.name}' tool was denied by the authorization gateway "
-                f"{attempts} times. Do not call this tool again in this session — "
-                "report the denial to the user and proceed with other tools."
-            ),
-        }
     return {
         "error": (
-            f"The '{tool.name}' tool call was denied by the authorization "
-            "gateway. This operation is not permitted by policy."
+            f"The '{tool.name}' tool call was blocked due to authorization policies. "
+            f"The agent is facing authorization issues / being blocked due to authz policies. "
+            f"Do not call this tool again in this session — report to the user that you are "
+            f"facing authorization issues or being blocked due to authorization policies, and proceed with other tools."
         ),
     }
 

--- a/demos/agent-gateway/src/mortgage-agent/deploy_agent.py
+++ b/demos/agent-gateway/src/mortgage-agent/deploy_agent.py
@@ -565,6 +565,9 @@ def main() -> None:
                 ],
             },
             env_vars={
+                # Make denied MCP tool calls (gateway 403) fail fast instead of
+                # hanging the turn as a broken-stream TaskGroup/TimeoutError.
+                "ADK_ENABLE_MCP_GRACEFUL_ERROR_HANDLING": "true",
                 "GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY": "true",
                 "GOOGLE_API_PREVENT_AGENT_TOKEN_SHARING_FOR_GCP_SERVICES": "false",
                 "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT": "true",

--- a/demos/agent-gateway/src/mortgage-agent/tests/test_agent.py
+++ b/demos/agent-gateway/src/mortgage-agent/tests/test_agent.py
@@ -80,16 +80,16 @@ def _make_tool_context(state: dict | None = None) -> MagicMock:
 
 
 class TestHandleToolError:
-    def test_403_returns_friendly_message(self):
+    def test_403_returns_block_message(self):
         tool = MagicMock()
         tool.name = "send_email"
         error = _make_http_status_error(403)
         result = _handle_tool_error(tool, {}, _make_tool_context(), error)
         assert result is not None
-        assert "denied" in result["error"]
         assert "send_email" in result["error"]
-        # First attempt should not be the hard-stop wording.
-        assert "Do not call this tool again" not in result["error"]
+        assert "authorization policies" in result["error"]
+        # No retries: the very first 403 is the hard-stop message.
+        assert "Do not call this tool again" in result["error"]
 
     def test_non_403_returns_none(self):
         tool = MagicMock()
@@ -105,14 +105,15 @@ class TestHandleToolError:
         result = _handle_tool_error(tool, {}, _make_tool_context(), error)
         assert result is None
 
-    def test_403_second_attempt_returns_hard_stop(self):
+    def test_403_blocks_immediately_and_counts_attempts(self):
         tool = MagicMock()
         tool.name = "send_email"
         error = _make_http_status_error(403)
         ctx = _make_tool_context()
 
         first = _handle_tool_error(tool, {}, ctx, error)
-        assert "Do not call this tool again" not in first["error"]
+        assert "Do not call this tool again" in first["error"]
+        assert ctx.state["_denied_mcp_tools"]["send_email"] == 1
 
         second = _handle_tool_error(tool, {}, ctx, error)
         assert "Do not call this tool again" in second["error"]
@@ -126,15 +127,15 @@ class TestHandleToolError:
         error = _make_http_status_error(403)
         ctx = _make_tool_context()
 
-        # Tool A hits the cap.
+        # Tool A is called twice; its counter is independent of tool B's.
         _handle_tool_error(tool_a, {}, ctx, error)
         _handle_tool_error(tool_a, {}, ctx, error)
         assert ctx.state["_denied_mcp_tools"]["send_email"] == 2
 
-        # Tool B's first attempt is still the friendly (non-hard-stop) message.
+        # Tool B's first 403 blocks immediately with its own counter.
         result = _handle_tool_error(tool_b, {}, ctx, error)
-        assert "Do not call this tool again" not in result["error"]
-        assert "denied" in result["error"]
+        assert "Do not call this tool again" in result["error"]
+        assert "authorization policies" in result["error"]
         assert ctx.state["_denied_mcp_tools"]["read_email"] == 1
 
 


### PR DESCRIPTION
- disable urllib3 PyOpenSSL injection to avoid the OTEL-exporter SSL-context crash
- ADK_ENABLE_MCP_GRACEFUL_ERROR_HANDLING so denied MCP calls fail fast
- _MAX_403_ATTEMPTS=1: block immediately on a 403 with a clear authz message
- update TestHandleToolError accordingly