### PR TITLE
feat(codelabs): add Agent Gateway egress to external MCP tutorial code

### DIFF
--- a/codelabs/about.md
+++ b/codelabs/about.md
@@ -11,3 +11,9 @@ The code within the subdirectories is intended to be checked out or downloaded a
 *   **Directory:** [`agw-cuj-arun-egress-gmcp/`](agw-cuj-arun-egress-gmcp/)
 *   **Description:** Implement agent governance with Agent Gateway deployed in agent-to-anywhere (egress) mode to authorize and secure outbound traffic from an Agent Runtime hosted agent accessing the Google Model Context Protocol (MCP) endpoint for BigQuery.
 *   **Published Codelab Link:** [https://codelabs.developers.google.com/agw-cuj-arun-egress-gmcp](https://codelabs.developers.google.com/agw-cuj-arun-egress-gmcp)
+
+### Agent Gateway egress from Agent Runtime to external MCP
+
+*   **Directory:** [`agw-cuj-arun-egress-emcp/`](agw-cuj-arun-egress-emcp/)
+*   **Description:** Implement agent governance with Agent Gateway deployed in agent-to-anywhere (egress) mode to authorize and secure outbound traffic from an Agent Runtime hosted agent accessing an external Model Context Protocol (MCP) endpoint using fine-grained conditional policies.
+*   **Published Codelab Link:** [https://codelabs.developers.google.com/agw-cuj-arun-egress-emcp](https://codelabs.developers.google.com/agw-cuj-arun-egress-emcp)

--- a/codelabs/agw-cuj-arun-egress-emcp/agent-datacommons/agent/__init__.py
+++ b/codelabs/agw-cuj-arun-egress-emcp/agent-datacommons/agent/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from . import agent

--- a/codelabs/agw-cuj-arun-egress-emcp/agent-datacommons/agent/agent.py
+++ b/codelabs/agw-cuj-arun-egress-emcp/agent-datacommons/agent/agent.py
@@ -1,0 +1,95 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Version 1.0.3
+
+import os
+import sys
+from typing import Any, Dict, Optional
+
+# Apply urllib3 PyOpenSSL workaround if available
+try:
+  import urllib3.contrib.pyopenssl
+  urllib3.contrib.pyopenssl.extract_from_urllib3()
+except Exception:
+  pass
+
+# Safely load environment variables from .env if present
+try:
+  from pathlib import Path
+  from dotenv import load_dotenv
+  for parent_level in [1, 2]:
+    env_path = Path(__file__).parents[parent_level] / '.env'
+    if env_path.exists():
+      load_dotenv(dotenv_path=env_path, override=True)
+      break
+except Exception:
+  pass
+
+import google.auth
+import google.auth.transport.requests
+from google.adk.agents import LlmAgent
+from google.adk.tools import McpToolset
+from google.adk.tools.mcp_tool import StreamableHTTPConnectionParams
+
+
+def get_auth_headers(context: Optional[Any] = None) -> Dict[str, str]:
+  """Fetches API authentication headers to pass to Data Commons MCP server."""
+  api_key = os.getenv('DC_API_KEY', '')
+  if not api_key:
+    print(
+        '[HeaderProvider] Warning: DC_API_KEY not found in environment.',
+        file=sys.stderr,
+    )
+  else:
+    print('[HeaderProvider] DC_API_KEY loaded successfully.', file=sys.stderr)
+
+  # Data Commons MCP public hosted server expects X-API-Key and Accepts event-stream
+  return {
+      'X-API-Key': api_key,
+      'Accept': 'application/json, text/event-stream',
+  }
+
+
+# Define connection parameters for Data Commons MCP toolset
+# Using the hosted public endpoint as documented by Data Commons
+mcp_url = os.getenv('MCP_URL', 'https://api.datacommons.org/mcp')
+connection_params = StreamableHTTPConnectionParams(url=mcp_url)
+
+# Instantiate Data Commons MCP Toolset
+datacommons_mcp_tools = McpToolset(
+    connection_params=connection_params,
+    header_provider=get_auth_headers,
+)
+
+
+# Define Standalone Root Agent utilizing Data Commons MCP tools
+datacommons_agent = LlmAgent(
+    name='agent_datacommons',
+    model='gemini-2.5-flash',
+    instruction=(
+        'You are a Data Commons statistical and knowledge graph assistant. Your'
+        ' purpose is to answer users\' queries about public statistics,'
+        ' demographics, geographic data, health indicators, and economic'
+        ' benchmarks by using your attached Data Commons MCP tools. Whenever'
+        ' a user asks for statistics or factual information about places or'
+        ' entities, use your Data Commons tools (such as search_indicators'
+        ' and get_observations) to fetch accurate, up-to-date factual'
+        ' data and provide clear, authoritative answers.'
+    ),
+    description='Standalone ADK agent utilizing 3P public Data Commons MCP tools.',
+    tools=[datacommons_mcp_tools],
+)
+
+root_agent = datacommons_agent

--- a/codelabs/agw-cuj-arun-egress-emcp/agent-datacommons/deploy_agent.py
+++ b/codelabs/agw-cuj-arun-egress-emcp/agent-datacommons/deploy_agent.py
@@ -62,7 +62,7 @@ def register_to_ge(
     auth_id = f"{agent_name}_{int(time.time() * 1000)}"
     auth_resource_name = f"projects/{project}/locations/global/authorizations/{auth_id}"
     auth_url = f"{base_url}/authorizations?authorizationId={auth_id}"
-    
+
     authorization_uri = (
         "https://accounts.google.com/o/oauth2/v2/auth"
         f"?client_id={oauth_client_id}"
@@ -73,7 +73,7 @@ def register_to_ge(
         "&access_type=offline"
         "&prompt=consent"
     )
-    
+
     auth_body = {
         "displayName": auth_id,
         "serverSideOauth2": {
@@ -157,13 +157,13 @@ def main():
     parser.add_argument("--enable-telemetry", action="store_true", help="Enable native Reasoning Engine telemetry")
     parser.add_argument("--allow-token-sharing", action="store_true", help="Allow agent identity token sharing for GCP services (disables bound token sharing)")
     parser.add_argument("-e", "--env-var", action="append", help="Additional environment variables to pass to deployed engine (format: KEY=VALUE)")
-    
+
     # Gemini Enterprise
     parser.add_argument("--ge-deploy", action="store_true", help="Register with Gemini Enterprise after deploy")
     parser.add_argument("--app-id", help="Gemini Enterprise App ID")
     parser.add_argument("--oauth-client-id", help="OAuth2 client ID")
     parser.add_argument("--oauth-client-secret", help="OAuth2 client secret")
-    
+
     args = parser.parse_args()
 
     if args.ge_deploy:
@@ -196,11 +196,11 @@ def main():
     # Staging Trick: Copy source to a temp directory named 'agent'
     staging_dir = tempfile.mkdtemp(prefix="agent_deploy_")
     original_cwd = os.getcwd()
-    
+
     try:
         src_abs_path = os.path.abspath(args.src_dir)
         agent_dest = os.path.join(staging_dir, "agent")
-        
+
         print(f"Staging agent code from {src_abs_path} to {agent_dest}...")
         shutil.copytree(
             src_abs_path,
@@ -336,10 +336,10 @@ def main():
             tn_value = args.target_network
             if not tn_value.startswith("projects/"):
                 tn_value = f"projects/{network_project}/global/networks/{tn_value}"
-                
+
             if "psc_interface_config" not in deploy_config:
                 deploy_config["psc_interface_config"] = {}
-                
+
             deploy_config["psc_interface_config"]["dns_peering_configs"] = [
                 {
                     "domain": domain,

--- a/codelabs/agw-cuj-arun-egress-emcp/agent-datacommons/deploy_agent.py
+++ b/codelabs/agw-cuj-arun-egress-emcp/agent-datacommons/deploy_agent.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Version 12
+
+import argparse
+import importlib
+import json
+import os
+import shutil
+import stat
+import sys
+import tempfile
+import time
+from urllib.parse import urlparse
+
+import google.auth
+import google.auth.transport.requests
+import requests
+
+
+def register_to_ge(
+    *,
+    project: str,
+    app_id: str,
+    agent_name: str,
+    display_name: str,
+    description: str,
+    reasoning_engine_name: str,
+    oauth_client_id: str,
+    oauth_client_secret: str,
+) -> None:
+    """Register an Agent Engine agent in Gemini Enterprise.
+
+    Includes creation of authorization to prevent consent loops.
+    """
+    credentials, _ = google.auth.default()
+    auth_req = google.auth.transport.requests.Request()
+    credentials.refresh(auth_req)
+    access_token = credentials.token
+
+    base_url = f"https://global-discoveryengine.googleapis.com/v1alpha/projects/{project}/locations/global"
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
+        "X-Goog-User-Project": project,
+    }
+
+    # Create authorization with timestamp-suffixed ID (avoids consent loop)
+    auth_id = f"{agent_name}_{int(time.time() * 1000)}"
+    auth_resource_name = f"projects/{project}/locations/global/authorizations/{auth_id}"
+    auth_url = f"{base_url}/authorizations?authorizationId={auth_id}"
+    
+    authorization_uri = (
+        "https://accounts.google.com/o/oauth2/v2/auth"
+        f"?client_id={oauth_client_id}"
+        "&redirect_uri=https%3A%2F%2Fvertexaisearch.cloud.google.com%2Fstatic%2Foauth%2Foauth.html"
+        "&scope=https://www.googleapis.com/auth/cloud-platform"
+        "&include_granted_scopes=true"
+        "&response_type=code"
+        "&access_type=offline"
+        "&prompt=consent"
+    )
+    
+    auth_body = {
+        "displayName": auth_id,
+        "serverSideOauth2": {
+            "clientId": oauth_client_id,
+            "clientSecret": oauth_client_secret,
+            "tokenUri": "https://oauth2.googleapis.com/token",
+            "authorizationUri": authorization_uri,
+        },
+    }
+
+    print(f"Creating authorization '{auth_id}'...")
+    try:
+        response = requests.post(auth_url, headers=headers, json=auth_body)
+        response.raise_for_status()
+        auth_resp = response.json()
+        auth_resource_name = auth_resp.get("name", auth_resource_name)
+        print(f"  Authorization created: {auth_resource_name}")
+    except requests.exceptions.RequestException as e:
+        print(f"ERROR creating authorization: {e}")
+        if hasattr(e, 'response') and e.response is not None:
+            print(f"Response: {e.response.text}")
+        sys.exit(1)
+
+    # Create agent registration
+    agents_url = f"{base_url}/collections/default_collection/engines/{app_id}/assistants/default_assistant/agents"
+    agent_body = {
+        "displayName": display_name,
+        "description": description,
+        "adk_agent_definition": {
+            "provisioned_reasoning_engine": {
+                "reasoning_engine": reasoning_engine_name,
+            },
+        },
+        "authorization_config": {
+            "tool_authorizations": [
+                auth_resource_name,
+            ],
+        },
+        "sharingConfig": {
+            "scope": "ALL_USERS",
+        },
+        "agentInvocationSpec": {
+            "invocationMode": "AUTOMATIC",
+        },
+    }
+
+    print(f"Registering agent in Gemini Enterprise engine '{app_id}'...")
+    try:
+        response = requests.post(agents_url, headers=headers, json=agent_body)
+        response.raise_for_status()
+        agent_resp = response.json()
+        print(f"  Agent registered: {agent_resp.get('name', 'unknown')}")
+    except requests.exceptions.RequestException as e:
+        print(f"ERROR registering agent: {e}")
+        if hasattr(e, 'response') and e.response is not None:
+            print(f"Response: {e.response.text}")
+        sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Deploy ADK Agent to Agent Engine")
+    parser.add_argument("--project", required=True, help="Google Cloud Project ID")
+    parser.add_argument("--region", default="us-central1", help="Vertex AI Region")
+    parser.add_argument("--src-dir", required=True, help="Directory containing agent code (must contain agent.py)")
+    parser.add_argument("--staging-bucket", help="GCS bucket for staging (default: gs://PROJECT-staging)")
+    parser.add_argument("--ge-auth-name", default="my-agent", help="Internal name for GE authorization (default: my-agent)")
+    parser.add_argument("--display-name", default="My ADK Agent", help="Display name for the deployed agent")
+    parser.add_argument("--description", default="An ADK agent.", help="Agent description (applies to both Reasoning Engine and GE)")
+    # Advanced Options
+    parser.add_argument("--network-attachment", help="Network attachment for PSC Interface")
+    parser.add_argument("--agent-gateway-egress", help="Egress Agent Gateway resource name (Agent-to-Anywhere)")
+    parser.add_argument("--agent-gateway-ingress", help="Ingress Agent Gateway resource name (Client-to-Agent)")
+    parser.add_argument("--enable-agent-identity", action="store_true", help="Enable Agent Identity")
+    parser.add_argument("--network-project", help="Project ID where network resources reside (defaults to --project)")
+    parser.add_argument("--target-network", help="Target network name or URI for DNS peering")
+    parser.add_argument("--dns-domains", help="Comma-separated list of domains for DNS peering")
+    parser.add_argument("--mcp-server-url", help="MCP Server URL to set in environment")
+    parser.add_argument("--data-bucket", help="GCS bucket name for customer data")
+    parser.add_argument("--endpoint-url", help="Endpoint URL for Quote of the Day service")
+    parser.add_argument("--re-custom-sa", help="Custom service account for Reasoning Engine")
+    parser.add_argument("--enable-telemetry", action="store_true", help="Enable native Reasoning Engine telemetry")
+    parser.add_argument("--allow-token-sharing", action="store_true", help="Allow agent identity token sharing for GCP services (disables bound token sharing)")
+    parser.add_argument("-e", "--env-var", action="append", help="Additional environment variables to pass to deployed engine (format: KEY=VALUE)")
+    
+    # Gemini Enterprise
+    parser.add_argument("--ge-deploy", action="store_true", help="Register with Gemini Enterprise after deploy")
+    parser.add_argument("--app-id", help="Gemini Enterprise App ID")
+    parser.add_argument("--oauth-client-id", help="OAuth2 client ID")
+    parser.add_argument("--oauth-client-secret", help="OAuth2 client secret")
+    
+    args = parser.parse_args()
+
+    if args.ge_deploy:
+        if not args.app_id or not args.oauth_client_id or not args.oauth_client_secret:
+            parser.error("Gemini Enterprise deployment requires --app-id, --oauth-client-id, and --oauth-client-secret")
+
+    staging_bucket = args.staging_bucket or f"gs://{args.project}-staging"
+    if not staging_bucket.startswith("gs://"):
+        staging_bucket = f"gs://{staging_bucket}"
+
+    print("Initializing Vertex AI...")
+    import vertexai
+    vertexai.init(
+        project=args.project,
+        location=args.region,
+        staging_bucket=staging_bucket,
+    )
+
+    # Initialize client with correct API version if Agent Identity is requested
+    if args.enable_agent_identity:
+        from vertexai import types
+        client = vertexai.Client(
+            project=args.project,
+            location=args.region,
+            http_options=dict(api_version="v1beta1")
+        )
+    else:
+        client = vertexai.Client(project=args.project, location=args.region)
+
+    # Staging Trick: Copy source to a temp directory named 'agent'
+    staging_dir = tempfile.mkdtemp(prefix="agent_deploy_")
+    original_cwd = os.getcwd()
+    
+    try:
+        src_abs_path = os.path.abspath(args.src_dir)
+        agent_dest = os.path.join(staging_dir, "agent")
+        
+        print(f"Staging agent code from {src_abs_path} to {agent_dest}...")
+        shutil.copytree(
+            src_abs_path,
+            agent_dest,
+            ignore=shutil.ignore_patterns("__pycache__", "*.pyc", ".pytest_cache", ".venv"),
+        )
+
+        # Add staging dir to path to import the newly copied agent
+        if staging_dir not in sys.path:
+            sys.path.insert(0, staging_dir)
+
+        # Import agent after vertexai.init
+        try:
+            from vertexai.agent_engines import AdkApp
+            agent_module = importlib.import_module("agent.agent")
+            root_agent = agent_module.root_agent
+            app = AdkApp(agent=root_agent)
+        except ImportError as e:
+            print(f"ERROR: Failed to import agent from staged directory: {e}")
+            sys.exit(1)
+
+        # Create installation_scripts/ with workaround for platform bug
+        scripts_dir = os.path.join(staging_dir, "installation_scripts")
+        os.makedirs(scripts_dir)
+        script_path = os.path.join(scripts_dir, "create_venv.sh")
+        with open(script_path, "w") as f:
+            f.write("#!/bin/bash\n")
+            f.write("set -e\n")
+            f.write("PYTHON3=$(which python3)\n")
+            f.write("PY_VER=$(python3 -c 'import sys; print(f\"{sys.version_info.major}.{sys.version_info.minor}\")')\n")
+            f.write("mkdir -p /code/.venv/bin\n")
+            f.write("mkdir -p /code/.venv/lib/python${PY_VER}/site-packages\n")
+            f.write('ln -sf "$PYTHON3" /code/.venv/bin/python\n')
+            f.write('ln -sf "$PYTHON3" /code/.venv/bin/python3\n')
+            f.write("cat > /code/.venv/pyvenv.cfg << PYCFG\n")
+            f.write("home = $(dirname $PYTHON3)\n")
+            f.write("include-system-site-packages = true\n")
+            f.write("PYCFG\n")
+        os.chmod(script_path, stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP)
+
+        os.chdir(staging_dir)
+
+        # Read requirements from pyproject.toml
+        import tomllib
+        requirements = []
+        try:
+            # Look for pyproject.toml relative to this script's directory
+            script_dir = os.path.dirname(os.path.abspath(__file__))
+            pyproject_path = os.path.join(script_dir, "pyproject.toml")
+            with open(pyproject_path, "rb") as f:
+                pyproject = tomllib.load(f)
+                requirements = pyproject.get("project", {}).get("dependencies", [])
+                print(f"Loaded {len(requirements)} requirements from {pyproject_path}")
+        except FileNotFoundError:
+            print(f"WARNING: pyproject.toml not found at {pyproject_path}. Using fallback requirements.")
+            requirements = [
+                "google-cloud-aiplatform[adk,agent_engines]",
+                "google-auth>=2.0",
+            ]
+
+        # Build config
+        deploy_config = {
+            "display_name": args.display_name,
+            "description": args.description,
+            "staging_bucket": staging_bucket,
+            "requirements": requirements,
+            "extra_packages": [
+                "agent",
+                "installation_scripts/create_venv.sh",
+            ],
+            "build_options": {
+                "installation_scripts": [
+                    "installation_scripts/create_venv.sh",
+                ],
+            },
+            "env_vars": {
+                "GOOGLE_GENAI_USE_VERTEXAI": "True",
+                "GOOGLE_API_USE_CLIENT_CERTIFICATE": "false",
+                "GOOGLE_API_USE_MTLS_ENDPOINT": "never",
+            },
+        }
+
+        if args.mcp_server_url:
+            deploy_config["env_vars"]["MCP_URL"] = args.mcp_server_url
+
+        if args.env_var:
+            for item in args.env_var:
+                if "=" in item:
+                    k, v = item.split("=", 1)
+                    deploy_config["env_vars"][k.strip()] = v.strip()
+
+        if args.data_bucket:
+            deploy_config["env_vars"]["DATA_BUCKET"] = args.data_bucket
+
+        if args.endpoint_url:
+            deploy_config["env_vars"]["ENDPOINT_URL"] = args.endpoint_url
+
+        if args.enable_telemetry:
+            deploy_config["env_vars"]["GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY"] = "true"
+            deploy_config["env_vars"]["OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"] = "true"
+
+        if args.enable_agent_identity:
+            deploy_config["identity_type"] = "AGENT_IDENTITY"
+
+        if args.allow_token_sharing:
+            deploy_config["env_vars"]["GOOGLE_API_PREVENT_AGENT_TOKEN_SHARING_FOR_GCP_SERVICES"] = "false"
+
+        network_project = args.network_project or args.project
+
+        if args.network_attachment:
+            na_value = args.network_attachment
+            if not na_value.startswith("projects/"):
+                na_value = f"projects/{network_project}/regions/{args.region}/networkAttachments/{na_value}"
+            deploy_config["psc_interface_config"] = {"network_attachment": na_value}
+
+        if args.agent_gateway_egress or args.agent_gateway_ingress:
+            deploy_config["agent_gateway_config"] = {}
+            if args.agent_gateway_egress:
+                deploy_config["agent_gateway_config"]["agent_to_anywhere_config"] = {
+                    "agent_gateway": args.agent_gateway_egress
+                }
+            if args.agent_gateway_ingress:
+                deploy_config["agent_gateway_config"]["client_to_agent_config"] = {
+                    "agent_gateway": args.agent_gateway_ingress
+                }
+
+        # NATIVE SDK SCHEMA MATCH:
+        # To support private DNS resolution of endpoints (like internal Cloud Run servers)
+        # over PSC, DNS Peering must be configured inside the psc_interface_config.dns_peering_configs list.
+        # Setting it as a root-level key (dns_peering_config) is rejected by the client-side PscInterfaceConfig validator.
+        if args.target_network:
+            domains = args.dns_domains.split(",") if args.dns_domains else ["run.app.", "foo.lab."]
+            tn_value = args.target_network
+            if not tn_value.startswith("projects/"):
+                tn_value = f"projects/{network_project}/global/networks/{tn_value}"
+                
+            if "psc_interface_config" not in deploy_config:
+                deploy_config["psc_interface_config"] = {}
+                
+            deploy_config["psc_interface_config"]["dns_peering_configs"] = [
+                {
+                    "domain": domain,
+                    "target_project": network_project,
+                    "target_network": tn_value,
+                }
+                for domain in domains
+            ]
+
+        if args.re_custom_sa:
+            deploy_config["service_account"] = args.re_custom_sa
+
+        print(f"Deploying agent '{args.display_name}'...")
+        engine = client.agent_engines.create(agent=app, config=deploy_config)
+
+    finally:
+        os.chdir(original_cwd)
+        shutil.rmtree(staging_dir, ignore_errors=True)
+
+    reasoning_engine_name = engine.api_resource.name
+    print(f"SUCCESS: Agent deployed: {reasoning_engine_name}")
+
+    if args.ge_deploy:
+        register_to_ge(
+            project=args.project,
+            app_id=args.app_id,
+            agent_name=args.ge_auth_name,
+            display_name=args.display_name,
+            description=args.description,
+            reasoning_engine_name=reasoning_engine_name,
+            oauth_client_id=args.oauth_client_id,
+            oauth_client_secret=args.oauth_client_secret,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/codelabs/agw-cuj-arun-egress-emcp/agent-datacommons/pyproject.toml
+++ b/codelabs/agw-cuj-arun-egress-emcp/agent-datacommons/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "agent-datacommons"
+version = "1.0.3"
+description = "Agent for Data Commons stats deployed on Agent Runtime using public Data Commons MCP tools"
+requires-python = ">=3.11,<3.13"
+dependencies = [
+    "google-adk==1.31.1",
+    "google-genai",
+    "pydantic",
+    "google-cloud-aiplatform[agent_engines,adk]>=1.40.0",
+    "cloudpickle>=3.0.0",
+    "python-dotenv",
+    "opentelemetry-instrumentation-httpx",
+    "opentelemetry-instrumentation-grpc",
+    "opentelemetry-instrumentation-google-genai",
+]

--- a/codelabs/agw-cuj-arun-egress-emcp/agent-datacommons/test_mcp.py
+++ b/codelabs/agw-cuj-arun-egress-emcp/agent-datacommons/test_mcp.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Version 05
+
+# /// script
+# dependencies = [
+#   "mcp",
+#   "httpx",
+# ]
+# ///
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import base64
+from urllib.parse import urlparse
+from mcp import ClientSession
+from mcp.client.sse import sse_client
+import httpx
+
+
+class DummyTool:
+    def __init__(self, data):
+        self.name = data.get("name")
+        self.description = data.get("description")
+        self.inputSchema = data.get("inputSchema", {})
+
+    def model_dump(self, **kwargs):
+        return {
+            "name": self.name,
+            "description": self.description,
+            "inputSchema": self.inputSchema,
+        }
+
+
+class StatelessHTTPClient:
+    """A portable, generic client for MCP servers that use stateless HTTP JSON-RPC."""
+    def __init__(self, url: str, headers: dict):
+        self.url = url
+        self.headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        }
+        if headers:
+            self.headers.update(headers)
+        self.client = httpx.AsyncClient()
+
+    async def _post(self, method: str, params: dict = None):
+        payload = {"jsonrpc": "2.0", "method": method, "id": 1}
+        if params is not None:
+            payload["params"] = params
+
+        response = await self.client.post(
+            self.url, headers=self.headers, json=payload, timeout=30.0
+        )
+        response.raise_for_status()
+
+        # Support both standard JSON responses and Server-Sent Events (event-stream)
+        # where JSON objects are prefixed with "data: ".
+        text = response.text
+        json_str = ""
+        for line in text.splitlines():
+            if line.startswith("data: "):
+                json_str = line[6:]
+                break
+        if not json_str:
+            json_str = text
+
+        try:
+            data = json.loads(json_str)
+        except json.JSONDecodeError as e:
+            raise Exception(f"Failed to parse JSON response: {text[:200]}") from e
+
+        if "error" in data:
+            raise Exception(f"RPC Error: {data['error']}")
+        return data.get("result", {})
+
+    async def list_tools(self):
+        res = await self._post("tools/list")
+        tools_list = res.get("tools", [])
+        
+        class ToolsResponse:
+            tools = [DummyTool(t) for t in tools_list]
+            
+        return ToolsResponse()
+
+    async def call_tool(self, name: str, arguments: dict = None):
+        res = await self._post(
+            "tools/call", {"name": name, "arguments": arguments or {}}
+        )
+        content = res.get("content", [])
+        
+        class DummyContent:
+            def __init__(self, c):
+                self.text = c.get("text", str(c))
+                
+        class ResultResponse:
+            content = [DummyContent(c) for c in content]
+            
+        return ResultResponse()
+
+
+def generate_sample_json(schema):
+    """Generate a sample JSON object based on a JSON schema."""
+    sample = {}
+    properties = schema.get("properties", {})
+    required = schema.get("required", [])
+
+    for prop_name, prop_info in properties.items():
+        if prop_name in required:
+            prop_type = prop_info.get("type", "string")
+            if prop_type == "string":
+                sample[prop_name] = "example_string"
+            elif prop_type == "number":
+                sample[prop_name] = 0.0
+            elif prop_type == "integer":
+                sample[prop_name] = 0
+            elif prop_type == "boolean":
+                sample[prop_name] = True
+            elif prop_type == "object":
+                sample[prop_name] = {}
+            elif prop_type == "array":
+                sample[prop_name] = []
+            else:
+                sample[prop_name] = None
+    return sample
+
+
+async def run_session(session, args, log):
+    # 1. List tools
+    response = await session.list_tools()
+    log(f"\nAvailable tools ({len(response.tools)}):")
+    for tool in response.tools:
+        log(f"- {tool.name}: {tool.description}")
+
+    # 2. Output toolspec if requested
+    if args.toolspec == "include":
+        tools_data = []
+        for tool in response.tools:
+            try:
+                tool_dict = tool.model_dump(exclude_none=True)
+            except AttributeError:
+                tool_dict = {
+                    "name": tool.name,
+                    "description": tool.description,
+                    "inputSchema": tool.inputSchema,
+                }
+            tools_data.append(tool_dict)
+
+        output_file = "toolspec.json"
+        # Wrap in "tools" key for registry compatibility
+        output_data = {"tools": tools_data}
+        with open(output_file, "w") as f:
+            json.dump(output_data, f, indent=2)
+        log(f"\n[SUCCESS] Wrote tool spec to {output_file}")
+
+        # Generate and print example usage
+        if response.tools:
+            first_tool = response.tools[0]
+            schema = getattr(first_tool, "inputSchema", {})
+            sample_args = generate_sample_json(schema)
+            sample_json = json.dumps(sample_args)
+            if args.printarg:
+                print(f"export TOOL_ARG='{sample_json}'")
+            else:
+                log(f"\nRun this to set the arguments:")
+                log(f"export TOOL_ARG='{sample_json}'")
+                log(f"\nThen run:")
+                log(
+                    f'uv run test_mcp.py --toolcall=include --toolargs="$TOOL_ARG"'
+                )
+
+    # 3. Test calling a tool if requested
+    if args.toolcall == "include" and response.tools:
+        # Find the first tool with no required arguments
+        target_tool = None
+        for tool in response.tools:
+            schema = getattr(tool, "inputSchema", {})
+            if not schema.get("required"):
+                target_tool = tool
+                break
+
+        # Fall back to the first tool if all require arguments
+        if not target_tool:
+            target_tool = response.tools[0]
+
+        log(f"\nTesting tool call for: '{target_tool.name}'...")
+
+        arguments = {}
+        if args.toolargs:
+            try:
+                arguments = json.loads(args.toolargs)
+            except json.JSONDecodeError as e:
+                print(f"Error: --toolargs is not valid JSON: {e}")
+                return
+
+        try:
+            result = await session.call_tool(
+                target_tool.name, arguments=arguments
+            )
+            log(f"Result from server:")
+            for item in result.content:
+                log(getattr(item, "text", str(item)))
+        except Exception as e:
+            log(
+                f"Called tool '{target_tool.name}', received response/error: {e}"
+            )
+            log("Note: If this tool requires arguments, an error is expected.")
+
+
+def parse_headers_arg(headers_arg):
+    headers = {}
+    if not headers_arg:
+        return headers
+    try:
+        headers = json.loads(headers_arg)
+        if isinstance(headers, dict):
+            return {str(k): str(v) for k, v in headers.items()}
+    except json.JSONDecodeError:
+        pass
+
+    # Split by comma or newline
+    for part in headers_arg.replace("\n", ",").split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "=" in part:
+            k, v = part.split("=", 1)
+            headers[k.strip()] = v.strip()
+        elif ":" in part:
+            k, v = part.split(":", 1)
+            headers[k.strip()] = v.strip()
+    return headers
+
+
+async def main():
+    parser = argparse.ArgumentParser(
+        description="Universal MCP Server Testing and Toolspec Utility"
+    )
+    parser.add_argument(
+        "--toolspec",
+        choices=["include", "exclude"],
+        default="exclude",
+        help="Output a toolspec.json file in registry-compatible format.",
+    )
+    parser.add_argument(
+        "--toolcall",
+        choices=["include", "exclude"],
+        default="exclude",
+        help="Test calling a tool (prefers tools with no required arguments).",
+    )
+    parser.add_argument(
+        "--toolargs",
+        help="JSON string of arguments to pass to the tool call.",
+    )
+    parser.add_argument(
+        "--printarg",
+        action="store_true",
+        help="Print only the export command for eval.",
+    )
+    parser.add_argument(
+        "--transport",
+        choices=["auto", "sse", "http"],
+        default="auto",
+        help="MCP transport to use ('sse' for standard Server-Sent Events, 'http' for stateless HTTP JSON-RPC).",
+    )
+    parser.add_argument(
+        "--headers",
+        help="Custom headers to pass to the MCP server (JSON string, or comma-separated Key=Value or Key:Value pairs).",
+    )
+    parser.add_argument(
+        "--token",
+        help="API key or token to pass in Authorization Bearer and X-API-Key headers.",
+    )
+    args = parser.parse_args()
+
+    def log(msg, **kwargs):
+        if args.printarg:
+            print(msg, file=sys.stderr, **kwargs)
+        else:
+            print(msg, **kwargs)
+
+    url = os.getenv("MCP_URL")
+    if not url:
+        log("Error: MCP_URL environment variable not set.")
+        return
+
+    # Hydrate headers from CLI or Environment
+    headers = parse_headers_arg(args.headers)
+    if not headers and os.getenv("MCP_HEADERS"):
+        headers = parse_headers_arg(os.getenv("MCP_HEADERS"))
+
+    # If no explicit credentials exist in headers, hydrate from --token flag or standard auth environment variables
+    auth_keys_present = any(h.lower() in ["authorization", "x-api-key"] for h in headers)
+    if not auth_keys_present:
+        token = (
+            args.token
+            or os.getenv("API_KEY")
+            or os.getenv("ID_TOKEN")
+            or os.getenv("MCP_TOKEN")
+        )
+        if token:
+            headers["X-API-Key"] = token
+            headers["Authorization"] = f"Bearer {token}"
+
+    log(f"Connecting to MCP server at: {url}")
+    if headers:
+        secure_headers_log = {k: "..." if "key" in k.lower() or "auth" in k.lower() or "token" in k.lower() else v for k, v in headers.items()}
+        log(f"Using headers: {secure_headers_log}")
+
+    transport = args.transport
+    if transport == "auto":
+        # Smart Auto-detection
+        if url.rstrip("/").endswith("/sse"):
+            log("[Auto-Detect] URL ends with /sse. Selecting SSE transport.")
+            transport = "sse"
+        else:
+            log("[Auto-Detect] Probing URL for stateless HTTP JSON-RPC...")
+            probe = StatelessHTTPClient(url, headers)
+            try:
+                await probe.list_tools()
+                log("[Auto-Detect] Stateless HTTP JSON-RPC probe successful!")
+                transport = "http"
+            except Exception as e:
+                log(f"[Auto-Detect] Stateless HTTP probe failed ({e}). Selecting SSE transport.")
+                transport = "sse"
+
+    if transport == "http":
+        log("Using Stateless HTTP JSON-RPC transport.")
+        client = StatelessHTTPClient(url, headers)
+        await run_session(client, args, log)
+    else:
+        log("Using Server-Sent Events (SSE) transport.")
+        if not url.endswith("/sse"):
+            url = url.rstrip("/") + "/sse"
+
+        async with sse_client(url, headers=headers) as (read_stream, write_stream):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                log("SSE Session initialized successfully!")
+                await run_session(session, args, log)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/codelabs/agw-cuj-arun-egress-emcp/agent-datacommons/test_mcp.py
+++ b/codelabs/agw-cuj-arun-egress-emcp/agent-datacommons/test_mcp.py
@@ -93,10 +93,10 @@ class StatelessHTTPClient:
     async def list_tools(self):
         res = await self._post("tools/list")
         tools_list = res.get("tools", [])
-        
+
         class ToolsResponse:
             tools = [DummyTool(t) for t in tools_list]
-            
+
         return ToolsResponse()
 
     async def call_tool(self, name: str, arguments: dict = None):
@@ -104,14 +104,14 @@ class StatelessHTTPClient:
             "tools/call", {"name": name, "arguments": arguments or {}}
         )
         content = res.get("content", [])
-        
+
         class DummyContent:
             def __init__(self, c):
                 self.text = c.get("text", str(c))
-                
+
         class ResultResponse:
             content = [DummyContent(c) for c in content]
-            
+
         return ResultResponse()
 
 

--- a/codelabs/agw-cuj-arun-egress-emcp/endpoints/googleapis.txt
+++ b/codelabs/agw-cuj-arun-egress-emcp/endpoints/googleapis.txt
@@ -1,0 +1,35 @@
+# global and locational (by region & multi-region) endpoints
+# {location}-{service}.googleapis.com
+# {location}-{service}.mtls.googleapis.com
+# and
+# {service}.googleapis.com
+# {service}.mtls.googleapis.com
+aiplatform.googleapis.com
+discoveryengine.googleapis.com
+
+# global and locational (by region only) endpoints
+# {location}-{service}.googleapis.com
+# {location}-{service}.mtls.googleapis.com
+# and
+# {service}.googleapis.com
+# {service}.mtls.googleapis.com
+agentregistry.googleapis.com
+
+# global endpoints
+# {service}.googleapis.com
+# {service}.mtls.googleapis.com
+global-discoveryengine.googleapis.com
+cloudresourcemanager.googleapis.com
+logging.googleapis.com
+monitoring.googleapis.com
+oauth2.googleapis.com
+trace.googleapis.com
+telemetry.googleapis.com
+iap.googleapis.com
+bigquery.googleapis.com
+storage.googleapis.com
+
+# regional endpoints
+# {service}.{region}.googleapis.com
+# {service}.{region}.mtls.googleapis.com
+modelarmor.googleapis.com

--- a/codelabs/agw-cuj-arun-egress-emcp/endpoints/register_endpoints.py
+++ b/codelabs/agw-cuj-arun-egress-emcp/endpoints/register_endpoints.py
@@ -1,0 +1,375 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Version 12
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+
+def get_gcloud_config(prop):
+    try:
+        result = subprocess.run(
+            ["gcloud", "config", "get-value", prop],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError:
+        return None
+
+def list_registered_services(project, location):
+    """Lists all currently registered services in the registry."""
+    cmd = [
+        "gcloud",
+        "alpha",
+        "agent-registry",
+        "services",
+        "list",
+        f"--project={project}",
+        f"--location={location}",
+        "--format=json"
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        return json.loads(result.stdout)
+    except subprocess.CalledProcessError as e:
+        print(f"Error listing services in location {location}: {e.stderr}", file=sys.stderr)
+        return []
+
+def delete_service(service_id, project, location, dry_run=False):
+    """Deletes a service from the registry."""
+    cmd = [
+        "gcloud",
+        "alpha",
+        "agent-registry",
+        "services",
+        "delete",
+        service_id,
+        f"--project={project}",
+        f"--location={location}",
+        "--quiet"
+    ]
+    print(f"{'[DRY RUN] ' if dry_run else ''}Running: {' '.join(cmd)}")
+    if dry_run:
+        return True
+    try:
+        subprocess.run(cmd, check=True)
+        print(f"Successfully deleted service {service_id} in {location}")
+        return True
+    except subprocess.CalledProcessError as e:
+        print(f"Error deleting service {service_id} in {location}: {e}", file=sys.stderr)
+        return False
+
+def parse_googleapis_txt(file_path):
+    """Parses googleapis.txt into categorized services based on new taxonomy."""
+    categories = {
+        "global_and_locational_all": [],
+        "global_and_locational_region_only": [],
+        "global": [],
+        "regional_only": []
+    }
+
+    if not os.path.exists(file_path):
+        print(f"Error: File {file_path} not found.")
+        sys.exit(1)
+
+    current_category = None
+    with open(file_path, "r") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+
+            # Detect category based on comment section headings
+            if line.startswith("#"):
+                comment_content = line.lstrip("#").strip().lower()
+                if "global and locational (by region & multi-region)" in comment_content:
+                    current_category = "global_and_locational_all"
+                elif "global and locational (by region only)" in comment_content:
+                    current_category = "global_and_locational_region_only"
+                elif "global endpoints" in comment_content:
+                    current_category = "global"
+                elif "regional endpoints" in comment_content:
+                    current_category = "regional_only"
+                continue
+
+            # Add base hostname to the active category if it contains .googleapis.com or similar format
+            if current_category and (".googleapis.com" in line or line.endswith(".com")):
+                categories[current_category].append(line)
+
+    return categories
+
+def derive_resource_name(hostname, location, region_prefix=None):
+    """Derives the standardized registry resource name for a given hostname and registry location."""
+    name = hostname
+    if name.endswith(".googleapis.com"):
+        name = name[: -len(".googleapis.com")]
+    name = name.replace(".", "-")
+
+    # Align service_id with regional gateway discovery expected lookup ID
+    if location != "global" and region_prefix:
+        # Prepend region prefix if not already present
+        if not name.startswith(f"{region_prefix}-"):
+            name = f"{region_prefix}-{name}"
+
+    # Apply Smart Suffixing if the final name is too short (< 6 characters)
+    if len(name) < 6:
+        name = f"{name}-api"
+
+    return name
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Register Google API endpoints in the Vertex AI Agent Registry using cross-registry registration.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument(
+        "--region",
+        default=os.environ.get("REGION") or "us-central1",
+        help="Region to use for regional endpoint URL generation, registry partition, and policy targeting."
+    )
+    parser.add_argument(
+        "--multi-region",
+        default="none",
+        help="Multi-region location to include (e.g. us, eu, or none)."
+    )
+    parser.add_argument(
+        "--mtls-endpoints",
+        choices=["include", "exclude"],
+        default="exclude",
+        help="Whether to include or exclude mTLS endpoints."
+    )
+    parser.add_argument(
+        "--clear-all",
+        action="store_true",
+        help="Deregister/delete all registered services from active registry locations and exit."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print actions/commands without executing them."
+    )
+    parser.add_argument(
+        "--project",
+        default=os.environ.get("PROJ_ID") or get_gcloud_config("project"),
+        help="Google Cloud Project ID."
+    )
+
+    args = parser.parse_args()
+
+    if args.clear_all:
+        if args.multi_region != "none" or args.mtls_endpoints != "exclude":
+            print("Error: --clear-all cannot be combined with endpoint filtering flags (--multi-region, --mtls-endpoints).")
+            sys.exit(1)
+
+    if not args.project:
+        print("Error: Project ID not set and could not be determined from environment/gcloud config.")
+        sys.exit(1)
+
+    print(f"Using Project: {args.project}")
+
+    # --- Clear All Logic (Multi-Location Aware) ---
+    if args.clear_all:
+        locations_to_clear = ["global"]
+        if args.region and args.region.lower() != "none":
+            locations_to_clear.append(args.region)
+
+        locations_to_clear = sorted(list(set(locations_to_clear)))
+
+        print(f"\nListing registered services to clear in active locations: {', '.join(locations_to_clear)}...")
+        total_services_found = 0
+        success_count = 0
+
+        for loc in locations_to_clear:
+            print(f"\nScanning location: {loc}...")
+            services = list_registered_services(args.project, loc)
+            if not services:
+                print(f"No services found in location {loc}.")
+                continue
+
+            total_services_found += len(services)
+            print(f"Found {len(services)} services in {loc}. Starting deletion...")
+            for svc in services:
+                service_path = svc.get("name", "")
+                if not service_path:
+                    continue
+                service_id = service_path.split("/")[-1]
+                if delete_service(service_id, args.project, loc, dry_run=args.dry_run):
+                    success_count += 1
+
+        print(f"\nCleared {success_count}/{total_services_found} services successfully.")
+        sys.exit(0)
+
+    # --- Cross-Registry Endpoint Generation ---
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    file_path = os.path.join(script_dir, "googleapis.txt")
+    categories = parse_googleapis_txt(file_path)
+
+    # Dictionary mapping (derived_resource_name, registry_location) -> hostname
+    # This automatically de-duplicates collisions where global and regional variants derive to the same ID.
+    endpoints_map = {}
+
+    def add_endpoint(hostname, loc):
+        res_name = derive_resource_name(hostname, loc, args.region)
+        key = (res_name, loc)
+        if key in endpoints_map:
+            # If collision occurs, regionalized hostname is more specific, so overwrite/prefer it
+            if hostname.startswith(f"{args.region}-"):
+                endpoints_map[key] = hostname
+        else:
+            endpoints_map[key] = hostname
+
+    # 1. Process global endpoints -> Cross-register in global AND regional registries
+    for base in categories["global"]:
+        add_endpoint(base, "global")
+        if args.mtls_endpoints == "include":
+            add_endpoint(base.replace(".googleapis.com", ".mtls.googleapis.com"), "global")
+
+        if args.region and args.region.lower() != "none":
+            r_loc = args.region
+            add_endpoint(base, r_loc)
+            if args.mtls_endpoints == "include":
+                add_endpoint(base.replace(".googleapis.com", ".mtls.googleapis.com"), r_loc)
+
+    # 2. Process global and locational (by region only) endpoints
+    for base in categories["global_and_locational_region_only"]:
+        # Global variants -> Cross-register in global AND regional registries
+        add_endpoint(base, "global")
+        if args.mtls_endpoints == "include":
+            add_endpoint(base.replace(".googleapis.com", ".mtls.googleapis.com"), "global")
+
+        if args.region and args.region.lower() != "none":
+            r_loc = args.region
+            add_endpoint(base, r_loc)
+            if args.mtls_endpoints == "include":
+                add_endpoint(base.replace(".googleapis.com", ".mtls.googleapis.com"), r_loc)
+
+            # Regional variants ({region}-{service}) -> Register in regional registry ONLY
+            reg_host = f"{r_loc}-{base}"
+            add_endpoint(reg_host, r_loc)
+            if args.mtls_endpoints == "include":
+                add_endpoint(reg_host.replace(".googleapis.com", ".mtls.googleapis.com"), r_loc)
+
+    # 3. Process global and locational (by region & multi-region) endpoints
+    for base in categories["global_and_locational_all"]:
+        # Global variants -> Cross-register in global AND regional registries
+        add_endpoint(base, "global")
+        if args.mtls_endpoints == "include":
+            add_endpoint(base.replace(".googleapis.com", ".mtls.googleapis.com"), "global")
+
+        if args.region and args.region.lower() != "none":
+            r_loc = args.region
+            add_endpoint(base, r_loc)
+            if args.mtls_endpoints == "include":
+                add_endpoint(base.replace(".googleapis.com", ".mtls.googleapis.com"), r_loc)
+
+            # Regional variants ({region}-{service}) -> Register in regional registry ONLY
+            reg_host = f"{r_loc}-{base}"
+            add_endpoint(reg_host, r_loc)
+            if args.mtls_endpoints == "include":
+                add_endpoint(reg_host.replace(".googleapis.com", ".mtls.googleapis.com"), r_loc)
+
+        # Multi-region variants ({multi-region}-{service}) -> Cross-register in global AND regional registries
+        if args.multi_region and args.multi_region.lower() != "none":
+            m_loc = args.multi_region
+            mr_host = f"{m_loc}-{base}"
+            add_endpoint(mr_host, "global")
+            if args.mtls_endpoints == "include":
+                add_endpoint(mr_host.replace(".googleapis.com", ".mtls.googleapis.com"), "global")
+
+            if args.region and args.region.lower() != "none":
+                r_loc = args.region
+                add_endpoint(mr_host, r_loc)
+                if args.mtls_endpoints == "include":
+                    add_endpoint(mr_host.replace(".googleapis.com", ".mtls.googleapis.com"), r_loc)
+
+    # 4. Process strictly regional endpoints -> Register in regional registry ONLY
+    if args.region and args.region.lower() != "none":
+        r_loc = args.region
+        for base in categories["regional_only"]:
+            reg_host = base.replace(".googleapis.com", f".{r_loc}.googleapis.com")
+            add_endpoint(reg_host, r_loc)
+
+            if args.mtls_endpoints == "include":
+                reg_host_mtls = base.replace(".googleapis.com", f".{r_loc}.mtls.googleapis.com")
+                add_endpoint(reg_host_mtls, r_loc)
+
+    if not endpoints_map:
+        print("No endpoints matched the specified location/mTLS criteria.")
+        sys.exit(0)
+
+    # --- Fetch existing services in active locations for Smart Skipping ---
+    unique_target_locations = sorted(list(set(loc for res_name, loc in endpoints_map.keys())))
+    existing_services_by_location = {}
+
+    for loc in unique_target_locations:
+        print(f"Scanning location '{loc}' for existing registrations to enable smart skipping...")
+        services_list = list_registered_services(args.project, loc)
+        existing_names = set()
+        for svc in services_list:
+            svc_path = svc.get("name", "")
+            if svc_path:
+                existing_names.add(svc_path.split("/")[-1])
+        existing_services_by_location[loc] = existing_names
+
+    print(f"\nSelected {len(endpoints_map)} endpoints for registration:")
+    for (res_name, loc), host in sorted(endpoints_map.items()):
+        if res_name in existing_services_by_location.get(loc, set()):
+            print(f" - {host} in location '{loc}' (Service ID: {res_name}) -> [Already Registered - Skip]")
+        else:
+            print(f" - {host} in location '{loc}' (Service ID: {res_name}) -> [New - Will Register]")
+
+    # Perform registration with dynamic location routing and smart skipping
+    for (resource_name, registry_location), hostname in sorted(endpoints_map.items()):
+        # Smart Skip Check
+        if resource_name in existing_services_by_location.get(registry_location, set()):
+            continue
+
+        display_name = hostname
+        url = f"https://{hostname}"
+
+        print(f"\nRegistering {hostname} as {resource_name} in registry location {registry_location}...")
+        cmd = [
+            "gcloud",
+            "alpha",
+            "agent-registry",
+            "services",
+            "create",
+            resource_name,
+            f"--project={args.project}",
+            f"--location={registry_location}",
+            f"--display-name={display_name}",
+            "--endpoint-spec-type=no-spec",
+            f"--interfaces=url={url},protocolBinding=JSONRPC",
+        ]
+
+        print(f"{'[DRY RUN] ' if args.dry_run else ''}Running: {' '.join(cmd)}")
+        if args.dry_run:
+            continue
+
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+            print(f"Successfully registered {hostname} in {registry_location}")
+            if result.stdout:
+                print(result.stdout)
+        except subprocess.CalledProcessError as e:
+            print(f"Error registering {hostname} in {registry_location}: {e.stderr}", file=sys.stderr)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description
This PR introduces a new codelab for: **Agent Gateway egress from Agent Runtime to external MCP**.

## Changes
* Created `codelabs/agw-cuj-arun-egress-emcp/` containing the Python ADK `agent-datacommons`
* Includes python scripts for Agent Registry endpoint registration and MCP `toolspec.json` creation.
* Updated `about.md` with relevant notes pointing to the new Codelab.

## Relevant Links
* **Published Codelab:** [https://codelabs.developers.google.com/agw-cuj-arun-egress-emcp](https://codelabs.developers.google.com/agw-cuj-arun-egress-emcp)
* Note... this is to be published in near future and will contain all the detailed instructions on how to interact with code posted here