### PR TITLE
Updated main.tf agent-gateway module

### DIFF
--- a/demos/agent-gateway/terraform/modules/agent-gateway/main.tf
+++ b/demos/agent-gateway/terraform/modules/agent-gateway/main.tf
@@ -173,6 +173,7 @@ resource "google_network_services_authz_extension" "iap" {
 
   metadata = var.iap_iam_enforcement_mode != null ? {
     iamEnforcementMode = var.iap_iam_enforcement_mode
+    iapPolicyVersion = "V1"
   } : null
 }
 

--- a/demos/agent-gateway/terraform/modules/agent-gateway/main.tf
+++ b/demos/agent-gateway/terraform/modules/agent-gateway/main.tf
@@ -171,11 +171,14 @@ resource "google_network_services_authz_extension" "iap" {
   timeout   = var.authz_extension_timeout
   fail_open = var.authz_extension_fail_open
 
-  metadata = var.iap_iam_enforcement_mode != null ? {
-    iamEnforcementMode = var.iap_iam_enforcement_mode
-    iapPolicyVersion = "V1"
-  } : null
-}
+  metadata = merge(
+    {
+      iapPolicyVersion = "V1"
+    },
+    var.iap_iam_enforcement_mode != null ? {
+      iamEnforcementMode = var.iap_iam_enforcement_mode
+    } : {}
+  )
 
 # Model Armor CONTENT_AUTHZ service extension. Regional REP endpoint —
 # constructed from var.region. The extension passes the request/response


### PR DESCRIPTION
Added metadata property to agent-gateway terraform module.  Was getting errors applying Terraform that iapPolicyVersion was missing.

Error message: The request was invalid: iapPolicyVersion is a required key to be specified in metadata for IAP AuthzExtension with unspecified load balancing scheme.