### PR TITLE
refactor(agent-registry-endpoints): register Google APIs as one "googleapis" service

### DIFF
--- a/demos/agent-gateway/terraform/example.tfvars
+++ b/demos/agent-gateway/terraform/example.tfvars
@@ -238,23 +238,19 @@ enable_run_app_psc = false
 # Enable the Agent Registry endpoint provisioner
 enable_agent_registry_endpoints = true
 
-# Optional: Override the default list of Google APIs to register. Map key is
-# the service short name; value is the human-readable display name surfaced in
-# the Agent Registry UI.
-agent_registry_google_apis = {
-  aiplatform           = "Vertex AI Platform"
-  cloudresourcemanager = "Cloud Resource Manager"
-  discoveryengine      = "Discovery Engine"
-  logging              = "Logging"
-  monitoring           = "Monitoring"
-  oauth2               = "OAuth2"
-  telemetry            = "Telemetry"
-  trace                = "Trace"
-  agentregistry        = "Agent Registry"
-  iap                  = "Identity-Aware Proxy"
-  modelarmor           = "Model Armor"
-  iamcredentials       = "IAM Credentials"
-}
+# Optional: Override the default list of Google API endpoints to register. Each
+# entry registers one exact hostname (no automatic variant expansion). A
+# "{region}" token in id or url is replaced with var.region.
+agent_registry_endpoints = [
+  "https://agentregistry.googleapis.com",
+  "https://aiplatform.mtls.googleapis.com",
+  "https://cloudresourcemanager.mtls.googleapis.com",
+  "https://iamcredentials.mtls.googleapis.com",
+  "https://telemetry.mtls.googleapis.com",
+  "https://{region}-aiplatform.mtls.googleapis.com",
+  "https://{region}-aiplatform.googleapis.com",
+  "https://aiplatform.{region}.rep.googleapis.com",
+]
 
 # Optional: Override or add custom (non-Google) services to register
 agent_registry_custom_services = [

--- a/demos/agent-gateway/terraform/main.tf
+++ b/demos/agent-gateway/terraform/main.tf
@@ -539,9 +539,9 @@ resource "google_project_iam_member" "run_admin" {
 }
 
 # Phase 15: Agent Registry Endpoints — governance plane fronting the Google API
-# services AND the MCP Cloud Run services. Registers all regional, mTLS, and REP
-# variants of the specified Google APIs, plus one entry per MCP Cloud Run service
-# (URL = https://<service>.<mcp_internal_dns_zone.domain>).
+# services AND the MCP Cloud Run services. Registers each Google API endpoint in
+# var.agent_registry_endpoints exactly as listed, plus one entry per MCP Cloud
+# Run service (URL = https://<service>.<mcp_internal_dns_zone.domain>).
 module "agent_registry_endpoints" {
   count  = var.enable_agent_registry_endpoints ? 1 : 0
   source = "./modules/agent-registry-endpoints"
@@ -549,8 +549,8 @@ module "agent_registry_endpoints" {
   project_id = var.project_id
   location   = var.region
 
-  google_apis     = var.agent_registry_google_apis
-  custom_services = var.agent_registry_custom_services
+  google_api_endpoints = var.agent_registry_endpoints
+  custom_services      = var.agent_registry_custom_services
 
   mcp_servers = {
     for name in keys(var.mcp_services) : name => {

--- a/demos/agent-gateway/terraform/modules/agent-registry-endpoints/main.tf
+++ b/demos/agent-gateway/terraform/modules/agent-registry-endpoints/main.tf
@@ -38,36 +38,12 @@ locals {
     }
   }
 
-  # Flatten each Google API into its five endpoint variants (global, mTLS,
-  # locational, locational mTLS, and regional REP), keyed by service_id. IDs,
-  # display names, and URLs mirror the variants the old registration script
-  # produced 1:1.
-  google_api_variants = merge([
-    for id, name in var.google_apis : {
-      # service_id must be 4-63 chars ([a-z][a-z0-9-]{2,61}[a-z0-9]); pad API
-      # ids shorter than 4 chars (e.g. "iap") while keeping the real URL host.
-      (length(id) >= 4 ? id : "${id}-endpoint") = {
-        display_name = name
-        url          = "https://${id}.googleapis.com"
-      }
-      "${id}-mtls" = {
-        display_name = "${name} mTLS"
-        url          = "https://${id}.mtls.googleapis.com"
-      }
-      "${var.location}-${id}" = {
-        display_name = "${name} Locational"
-        url          = "https://${var.location}-${id}.googleapis.com"
-      }
-      "${var.location}-${id}-mtls" = {
-        display_name = "${name} Locational mTLS"
-        url          = "https://${var.location}-${id}.mtls.googleapis.com"
-      }
-      "${id}-${var.location}-rep" = {
-        display_name = "${name} Regional (REP)"
-        url          = "https://${id}.${var.location}.rep.googleapis.com"
-      }
-    }
-  ]...)
+  # Google API endpoint URLs, each registered as an interface under the single
+  # "googleapis" service below. A "{region}" token is replaced with var.location
+  # for portability (e.g. "{region}-aiplatform" -> "us-central1-aiplatform").
+  google_api_interface_urls = [
+    for url in var.google_api_endpoints : replace(url, "{region}", var.location)
+  ]
 }
 
 # Cross-variable input validation. Variable `validation` blocks can't reference
@@ -106,19 +82,21 @@ resource "terraform_data" "mcp_input_check" {
   }
 }
 
-# Google API endpoints (global, mTLS, locational, and REP variants). These are
-# plain endpoints with no spec, exposed over JSON-RPC.
+# All Google API endpoints registered as interfaces under a SINGLE "googleapis"
+# Agent Registry service (one entry, one interface per URL in
+# var.google_api_endpoints). Spec-less endpoint, JSON-RPC on every interface.
 resource "google_agent_registry_service" "google_apis" {
-  for_each = local.google_api_variants
-
   project      = var.project_id
   location     = var.location
-  service_id   = each.key
-  display_name = each.value.display_name
+  service_id   = "googleapis"
+  display_name = "Google APIs"
 
-  interfaces {
-    url              = each.value.url
-    protocol_binding = "JSONRPC"
+  dynamic "interfaces" {
+    for_each = local.google_api_interface_urls
+    content {
+      url              = interfaces.value
+      protocol_binding = "JSONRPC"
+    }
   }
 
   endpoint_spec {

--- a/demos/agent-gateway/terraform/modules/agent-registry-endpoints/outputs.tf
+++ b/demos/agent-gateway/terraform/modules/agent-registry-endpoints/outputs.tf
@@ -15,7 +15,7 @@
 output "service_ids" {
   description = "Map of registered Agent Registry service resource IDs, keyed by service_id."
   value = merge(
-    { for k, r in google_agent_registry_service.google_apis : k => r.id },
+    { (google_agent_registry_service.google_apis.service_id) = google_agent_registry_service.google_apis.id },
     { for k, r in google_agent_registry_service.custom : k => r.id },
     { for k, r in google_agent_registry_service.mcp : k => r.id },
   )

--- a/demos/agent-gateway/terraform/modules/agent-registry-endpoints/variables.tf
+++ b/demos/agent-gateway/terraform/modules/agent-registry-endpoints/variables.tf
@@ -22,23 +22,19 @@ variable "location" {
   type        = string
 }
 
-variable "google_apis" {
-  description = "Map of Google API IDs to their display names to register with all regional/mtls variants"
-  type        = map(string)
-  default = {
-    aiplatform             = "Vertex AI Platform"
-    cloudresourcemanager   = "Cloud Resource Manager"
-    global-discoveryengine = "Global Discovery Engine"
-    discoveryengine        = "Discovery Engine"
-    logging                = "Logging"
-    monitoring             = "Monitoring"
-    oauth2                 = "OAuth2"
-    telemetry              = "Telemetry"
-    trace                  = "Trace"
-    agentregistry          = "Agent Registry"
-    iap                    = "Identity-Aware Proxy"
-    iamcredentials         = "IAM Credentials"
-  }
+variable "google_api_endpoints" {
+  description = "Google API endpoint URLs registered as interfaces under a single \"googleapis\" Agent Registry service. A \"{region}\" token is replaced with var.location."
+  type        = list(string)
+  default = [
+    "https://agentregistry.googleapis.com",
+    "https://aiplatform.mtls.googleapis.com",
+    "https://cloudresourcemanager.mtls.googleapis.com",
+    "https://iamcredentials.mtls.googleapis.com",
+    "https://telemetry.mtls.googleapis.com",
+    "https://{region}-aiplatform.mtls.googleapis.com",
+    "https://{region}-aiplatform.googleapis.com",
+    "https://aiplatform.{region}.rep.googleapis.com",
+  ]
 }
 
 variable "custom_services" {

--- a/demos/agent-gateway/terraform/variables.tf
+++ b/demos/agent-gateway/terraform/variables.tf
@@ -468,22 +468,19 @@ variable "enable_agent_registry_endpoints" {
   default     = false
 }
 
-variable "agent_registry_google_apis" {
-  description = "Map of Google API IDs to their display names to register in Agent Registry"
-  type        = map(string)
-  default = {
-    aiplatform             = "Vertex AI Platform"
-    cloudresourcemanager   = "Cloud Resource Manager"
-    global-discoveryengine = "Global Discovery Engine"
-    discoveryengine        = "Discovery Engine"
-    logging                = "Logging"
-    monitoring             = "Monitoring"
-    oauth2                 = "OAuth2"
-    telemetry              = "Telemetry"
-    trace                  = "Trace"
-    agentregistry          = "Agent Registry"
-    iap                    = "Identity-Aware Proxy"
-  }
+variable "agent_registry_endpoints" {
+  description = "Google API endpoint URLs registered as interfaces under a single \"googleapis\" Agent Registry service. A \"{region}\" token is replaced with var.region."
+  type        = list(string)
+  default = [
+    "https://agentregistry.googleapis.com",
+    "https://aiplatform.mtls.googleapis.com",
+    "https://cloudresourcemanager.mtls.googleapis.com",
+    "https://iamcredentials.mtls.googleapis.com",
+    "https://telemetry.mtls.googleapis.com",
+    "https://{region}-aiplatform.mtls.googleapis.com",
+    "https://{region}-aiplatform.googleapis.com",
+    "https://aiplatform.{region}.rep.googleapis.com",
+  ]
 }
 
 variable "agent_registry_custom_services" {


### PR DESCRIPTION
Collapse the Google API endpoints from separate google_agent_registry_service resources into a single "googleapis" service that exposes each URL as a JSONRPC interface; simplify `agent_registry_endpoints` to a list of URL strings. GitHub remains its own registry entry.

Rebased onto `main`. The default-Gemini-model bump that was originally part of this branch has been dropped — `main` already sets `gemini-3.1-flash-lite` (#142), and PR #143 is touching the same lines.