### PR TITLE
fix(agent-gateway): make gateway provision cleanly under a perimeter

### DIFF
--- a/demos/agent-gateway/terraform/modules/agent-gateway/main.tf
+++ b/demos/agent-gateway/terraform/modules/agent-gateway/main.tf
@@ -86,7 +86,15 @@ resource "google_network_services_agent_gateway" "this" {
       content {
         domains        = dns_peering_config.value.domains
         target_project = dns_peering_config.value.target_project
-        target_network = dns_peering_config.value.target_network
+        # The AgentGateway API validates target_network by exact string match
+        # against the egress network attachment's network, which it reports in
+        # the partial "projects/<p>/global/networks/<n>" form. A full self-link
+        # URL fails validation ("... is in network X, not target network Y" for
+        # the same VPC), so strip the compute API prefix to the partial form.
+        target_network = trimprefix(
+          dns_peering_config.value.target_network,
+          "https://www.googleapis.com/compute/v1/"
+        )
       }
     }
   }
@@ -183,8 +191,12 @@ resource "google_network_security_authz_policy" "iap" {
 # When model_armor_authz_hosts is non-empty, scope the policy to the listed
 # Host header values via http_rules; otherwise the policy applies to all
 # gateway traffic.
+# Serialized after the IAP authz policy: both policies attach to the same Agent
+# Gateway, and the gateway backend allows only one mutating operation at a time
+# (concurrent creates fail with code 10 "another ongoing operation for the same
+# AgentGateway"). depends_on forces them to apply sequentially.
 resource "google_network_security_authz_policy" "model_armor" {
-  depends_on     = [time_sleep.wait_for_gateway]
+  depends_on     = [time_sleep.wait_for_gateway, google_network_security_authz_policy.iap]
   count          = var.enable_model_armor ? 1 : 0
   provider       = google-beta
   project        = var.project_id

--- a/demos/agent-gateway/terraform/modules/mcp-internal-lb/main.tf
+++ b/demos/agent-gateway/terraform/modules/mcp-internal-lb/main.tf
@@ -40,13 +40,23 @@ resource "google_compute_address" "lb" {
 # header (e.g. legacy-dms.mcp-server.internal) and routes to the Cloud Run
 # service named <service> in this region.
 resource "google_compute_region_network_endpoint_group" "mcp" {
-  project               = var.project_id
-  name                  = "${local.lb_name}-neg"
+  project = var.project_id
+  # Suffix the name with a short hash of the DNS domain. A url_mask change (e.g.
+  # switching the MCP domain) forces NEG replacement; the hashed name means the
+  # replacement NEG gets a NEW name, so — together with create_before_destroy —
+  # it is created and the backend service repointed to it BEFORE the old NEG is
+  # deleted. Without this, Terraform tries to delete the still-referenced old NEG
+  # and the API rejects it with resourceInUseByAnotherResource.
+  name                  = "${local.lb_name}-neg-${substr(sha256(local.dns_domain_no_dot), 0, 6)}"
   region                = var.region
   network_endpoint_type = "SERVERLESS"
 
   cloud_run {
     url_mask = "<service>.${local.dns_domain_no_dot}"
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 


### PR DESCRIPTION
- dns_peering_config.target_network: strip compute API prefix to the partial form the AgentGateway API validates against.
- serialize the IAP and Model Armor authz policies (depends_on) to avoid the gateway 'another ongoing operation' race.
- mcp-internal-lb: hash the serverless NEG name + create_before_destroy so a url_mask change replaces it without resourceInUseByAnotherResource.