### PR TITLE
fix(mortgage-agent): upgrade default model to gemini-3.1-flash-lite

### DIFF
--- a/demos/agent-gateway/src/mortgage-agent/agent/agent.py
+++ b/demos/agent-gateway/src/mortgage-agent/agent/agent.py
@@ -517,7 +517,7 @@ def _build_agent():
     instruction = _INSTRUCTION_TEMPLATE.format(mcp_services_doc=_render_mcp_services_doc())
 
     return _PickleSafeAgent(
-        model=os.environ.get("MODEL_NAME", "gemini-3.1-flash-lite-preview"),
+        model=os.environ.get("MODEL_NAME", "gemini-3.1-flash-lite"),
         name="mortgage_assistant_agent",
         description=(
             "A mortgage underwriting assistant that connects to legacy document management, "

--- a/demos/agent-gateway/src/mortgage-agent/deploy_agent.py
+++ b/demos/agent-gateway/src/mortgage-agent/deploy_agent.py
@@ -303,8 +303,8 @@ def main() -> None:
     )
     parser.add_argument(
         "--model",
-        default="gemini-3.1-flash-lite-preview",
-        help="Gemini model name for the agent (default: gemini-3.1-flash-lite-preview)",
+        default="gemini-3.1-flash-lite",
+        help="Gemini model name for the agent (default: gemini-3.1-flash-lite)",
     )
     parser.add_argument(
         "--model-endpoint-location",

--- a/demos/service-extensions-gke-gateway/src/mortgage-agent/agent/agent.py
+++ b/demos/service-extensions-gke-gateway/src/mortgage-agent/agent/agent.py
@@ -167,7 +167,7 @@ def _build_agent():
     )
 
     return _PickleSafeAgent(
-        model=os.environ.get("MODEL_NAME", "gemini-3.1-flash-lite-preview"),
+        model=os.environ.get("MODEL_NAME", "gemini-3.1-flash-lite"),
         name="mortgage_assistant_agent",
         description=(
             "A mortgage underwriting assistant that connects to legacy document management, "

--- a/demos/service-extensions-gke-gateway/src/mortgage-agent/deploy_agent.py
+++ b/demos/service-extensions-gke-gateway/src/mortgage-agent/deploy_agent.py
@@ -342,9 +342,9 @@ def main() -> None:
     )
     parser.add_argument(
         "--model",
-        default="gemini-3.1-flash-lite-preview",
-        help="Gemini model name for the agent (default: gemini-3.1-flash-lite-preview)",
-    )
+        default="gemini-3.1-flash-lite",
+        help="Gemini model name for the agent (default: gemini-3.1-flash-lite)",
+     )
     parser.add_argument(
         "--agent-location",
         default="us-central1",


### PR DESCRIPTION
Upgrades the default Gemini model used by the mortgage agents from the [deprecated](https://ai.google.dev/gemini-api/docs/deprecations#gemini-3-models) `gemini-3.1-flash-lite-preview` model (shutdown by May 25, 2026) to `gemini-3.1-flash-lite`.

Using the preview model results in a `not found` error or permission denial:
> Publisher model `projects/PROJECT_ID/locations/global/publishers/google/models/gemini-3.1-flash-lite-preview` was not found or your project does not have access to it.

## Changes

- **Agent Definitions:** Updated fallback model to `gemini-3.1-flash-lite` in:
  - `demos/agent-gateway/src/mortgage-agent/agent/agent.py`
  - `demos/service-extensions-gke-gateway/src/mortgage-agent/agent/agent.py`
- **Deployment Scripts:** Updated default arguments and help text in:
  - `demos/agent-gateway/src/mortgage-agent/deploy_agent.py`
  - `demos/service-extensions-gke-gateway/src/mortgage-agent/deploy_agent.py`

## Verification

Verified that the deprecated model string is no longer present in the codebase.
