### PR TITLE
fix(agw-cuj-arun-egress-vpc): pin mcp version and fix streamable-http…

### DIFF
--- a/codelabs/agw-cuj-arun-egress-vpc/mcp-weather/server/requirements.txt
+++ b/codelabs/agw-cuj-arun-egress-vpc/mcp-weather/server/requirements.txt
@@ -1,4 +1,4 @@
-mcp
+mcp>=1.26.0,<2.0.0
 httpx
 uvicorn
 starlette

--- a/codelabs/agw-cuj-arun-egress-vpc/mcp-weather/test_mcp.py
+++ b/codelabs/agw-cuj-arun-egress-vpc/mcp-weather/test_mcp.py
@@ -17,7 +17,7 @@
 
 # /// script
 # dependencies = [
-#   "mcp",
+#   "mcp>=1.26.0,<2.0.0",
 #   "httpx",
 # ]
 # ///
@@ -200,6 +200,9 @@ async def run_session(session, args, log):
                     "description": tool.description,
                     "inputSchema": tool.inputSchema,
                 }
+            # Ensure inputSchema is present for Agent Registry schema compliance
+            if not tool_dict.get("inputSchema"):
+                tool_dict["inputSchema"] = {"type": "object", "properties": {}}
             tools_data.append(tool_dict)
 
         output_file = "toolspec.json"
@@ -387,7 +390,11 @@ async def main():
     elif transport == "streamable-http":
         log("Using MCP 2025-03-26 Streamable HTTP transport.")
         http_client = httpx.AsyncClient(headers=headers) if headers else None
-        async with streamable_http_client(url, http_client=http_client) as (read_stream, write_stream, get_session_id):
+        async with streamable_http_client(url, http_client=http_client) as client_streams:
+            if len(client_streams) == 3:
+                read_stream, write_stream, _ = client_streams
+            else:
+                read_stream, write_stream = client_streams
             async with ClientSession(read_stream, write_stream) as session:
                 await session.initialize()
                 log("Streamable HTTP Session initialized successfully!")

--- a/demos/service-extensions-gke-gateway/src/mortgage-agent/deploy_agent.py
+++ b/demos/service-extensions-gke-gateway/src/mortgage-agent/deploy_agent.py
@@ -344,7 +344,7 @@ def main() -> None:
         "--model",
         default="gemini-3.1-flash-lite",
         help="Gemini model name for the agent (default: gemini-3.1-flash-lite)",
-     )
+    )
     parser.add_argument(
         "--agent-location",
         default="us-central1",


### PR DESCRIPTION
## Description
This PR updates the **Agent Gateway egress from Agent Runtime to VPC** codelab code to ensure compatibility with `mcp` 1.26+ releases and Agent Registry schema rules.

## Changes
* Pinned `mcp>=1.26.0,<2.0.0` in `server/requirements.txt` and inline script dependencies in `test_mcp.py`.
* Added `inputSchema` fallback in `test_mcp.py` for Agent Registry schema compliance.
* Fixed `streamable_http_client` context manager tuple unpacking in `test_mcp.py` to support variable return tuple lengths.
* Drive-by style fix: Formatted `deploy_agent.py` in mortgage-agent demo to resolve CI matrix formatting check.

## Relevant Links
* **Published Codelab:** [https://codelabs.developers.google.com/agw-cuj-arun-egress-vpc](https://codelabs.developers.google.com/agw-cuj-arun-egress-vpc)
* **PR:** #129