### PR TITLE
fix(agw-cuj-arun-egress-emcp): pin mcp version and add inputSchema fa…

### DIFF
--- a/codelabs/agw-cuj-arun-egress-emcp/agent-datacommons/test_mcp.py
+++ b/codelabs/agw-cuj-arun-egress-emcp/agent-datacommons/test_mcp.py
@@ -17,7 +17,7 @@
 
 # /// script
 # dependencies = [
-#   "mcp",
+#   "mcp>=1.26.0,<2.0.0",
 #   "httpx",
 # ]
 # ///
@@ -160,6 +160,9 @@ async def run_session(session, args, log):
                     "description": tool.description,
                     "inputSchema": tool.inputSchema,
                 }
+            # Ensure inputSchema is present for Agent Registry schema compliance
+            if not tool_dict.get("inputSchema"):
+                tool_dict["inputSchema"] = {"type": "object", "properties": {}}
             tools_data.append(tool_dict)
 
         output_file = "toolspec.json"


### PR DESCRIPTION
## Description
This PR updates the **Agent Gateway egress from Agent Runtime to external MCP** codelab test utility script to ensure compatibility with `mcp` 1.26+ releases and Agent Registry schema rules.

## Changes
* Pinned `mcp>=1.26.0,<2.0.0` in inline script dependencies in `agent-datacommons/test_mcp.py`.
* Added `inputSchema` fallback in `agent-datacommons/test_mcp.py` for Agent Registry schema compliance.

## Relevant Links
* **Published Codelab:** [https://codelabs.developers.google.com/agw-cuj-arun-egress-emcp](https://codelabs.developers.google.com/agw-cuj-arun-egress-emcp)