### PR TITLE
fix(agw-cuj-arun-egress-vpc): resolve MCP Streamable HTTP lifespan an…

### DIFF
--- a/codelabs/agw-cuj-arun-egress-vpc/agent-weather/agent/agent.py
+++ b/codelabs/agw-cuj-arun-egress-vpc/agent-weather/agent/agent.py
@@ -96,9 +96,9 @@ def get_auth_headers(context: Optional[Any] = None) -> Dict[str, str]:
     return {}
 
 
-# Define connection parameters for Weather MCP toolset
+# Define connection parameters for Weather MCP toolset with 30s timeout
 mcp_url = os.getenv('MCP_URL', 'http://localhost:8080/mcp')
-connection_params = StreamableHTTPConnectionParams(url=mcp_url)
+connection_params = StreamableHTTPConnectionParams(url=mcp_url, timeout=30.0)
 
 # Instantiate Weather MCP Toolset with OIDC authentication header provider
 weather_mcp_tools = McpToolset(

--- a/codelabs/agw-cuj-arun-egress-vpc/agent-weather/deploy_agent.py
+++ b/codelabs/agw-cuj-arun-egress-vpc/agent-weather/deploy_agent.py
@@ -218,6 +218,12 @@ def main():
         if staging_dir not in sys.path:
             sys.path.insert(0, staging_dir)
 
+        # Set environment variables from CLI args prior to importing agent
+        if args.mcp_server_url:
+            os.environ["MCP_URL"] = args.mcp_server_url
+        if args.mcp_invoker_sa:
+            os.environ["MCP_INVOKER_SA"] = args.mcp_invoker_sa
+
         # Import agent after vertexai.init
         try:
             from vertexai.agent_engines import AdkApp

--- a/codelabs/agw-cuj-arun-egress-vpc/mcp-weather/server/server.py
+++ b/codelabs/agw-cuj-arun-egress-vpc/mcp-weather/server/server.py
@@ -29,11 +29,10 @@ import uvicorn
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-# Initialize FastMCP with disabled DNS rebinding protection for Cloud Run (enabling json_response for Streamable HTTP)
+# Initialize FastMCP with disabled DNS rebinding protection for Cloud Run
 mcp = FastMCP(
     "Weather Server",
     transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False),
-    json_response=True,
 )
 
 GEOCODING_URL = "https://geocoding-api.open-meteo.com/v1/search"
@@ -168,4 +167,4 @@ if __name__ == "__main__":
     # Run the app using uvicorn (respecting PORT env var set by Cloud Run)
     port = int(os.getenv("PORT", "8080"))
     logger.info(f"Starting MCP Weather Server on port {port}")
-    uvicorn.run(app, host="0.0.0.0", port=port)
+    uvicorn.run(app, host="0.0.0.0", port=port, lifespan="on")


### PR DESCRIPTION
…d ADK packaging env injection

- Fix FastMCP initialization by removing json_response=True and setting lifespan='on' in uvicorn.run() to enable native Streamable HTTP protocol handling.
- Fix deploy_agent.py to inject MCP_URL and MCP_INVOKER_SA into os.environ before importing the staged agent module, preventing localhost serialization.
- Configure timeout=30.0 on StreamableHTTPConnectionParams in agent.py to handle gateway proxying and cold-start latencies.